### PR TITLE
[프레디]미션4, 5 동시 진행

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,9 +6,6 @@ name: CI
 on:
   # Triggers the workflow on push or pull request events but only for the main branch
   push:
-#     branches: [ * ]
-  pull_request:
-    branches: [ Dae-Hwa ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,8 @@ name: CI
 on:
   # Triggers the workflow on push or pull request events but only for the main branch
   push:
-
+    branches-ignore:
+      "Dae-Hwa"
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/src/main/java/com/codessquad/qna/QnaApplication.java
+++ b/src/main/java/com/codessquad/qna/QnaApplication.java
@@ -2,8 +2,10 @@ package com.codessquad.qna;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class QnaApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/codessquad/qna/answer/Answer.java
+++ b/src/main/java/com/codessquad/qna/answer/Answer.java
@@ -1,7 +1,9 @@
 package com.codessquad.qna.answer;
 
+import com.codessquad.qna.common.Constant;
 import com.codessquad.qna.question.Question;
 import com.codessquad.qna.user.User;
+import com.fasterxml.jackson.annotation.JsonFormat;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
@@ -14,7 +16,10 @@ public class Answer {
 
     private String comment;
     private boolean deleted;
+
+    @JsonFormat(pattern = Constant.DEFAULT_DATE_TIME_FORMAT)
     private LocalDateTime createDateTime;
+
     private LocalDateTime updateDateTime;
 
     @ManyToOne

--- a/src/main/java/com/codessquad/qna/answer/Answer.java
+++ b/src/main/java/com/codessquad/qna/answer/Answer.java
@@ -13,6 +13,7 @@ public class Answer {
     private Long id;
 
     private String comment;
+    private boolean deleted;
     private LocalDateTime createDateTime;
     private LocalDateTime updateDateTime;
 
@@ -40,6 +41,10 @@ public class Answer {
 
     public String getComment() {
         return comment;
+    }
+
+    public void delete() {
+        deleted = true;
     }
 
     public LocalDateTime getCreateDateTime() {

--- a/src/main/java/com/codessquad/qna/answer/Answer.java
+++ b/src/main/java/com/codessquad/qna/answer/Answer.java
@@ -115,10 +115,6 @@ public class Answer {
         return question;
     }
 
-    public void setQuestion(Question question) {
-        this.question = question;
-    }
-
     public User getWriter() {
         return writer;
     }

--- a/src/main/java/com/codessquad/qna/answer/Answer.java
+++ b/src/main/java/com/codessquad/qna/answer/Answer.java
@@ -1,5 +1,6 @@
 package com.codessquad.qna.answer;
 
+import com.codessquad.qna.common.BaseEntity;
 import com.codessquad.qna.question.Question;
 import com.codessquad.qna.user.User;
 
@@ -7,15 +8,9 @@ import javax.persistence.*;
 import java.time.LocalDateTime;
 
 @Entity
-public class Answer {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-
+public class Answer extends BaseEntity {
     private String comment;
     private boolean deleted;
-    private LocalDateTime createDateTime;
-    private LocalDateTime updateDateTime;
 
     @ManyToOne
     @JoinColumn(foreignKey = @ForeignKey(name = "fk_answer_question"))
@@ -29,11 +24,10 @@ public class Answer {
     }
 
     public Answer(Long id, String comment, boolean deleted, LocalDateTime createDateTime, LocalDateTime updateDateTime, Question question, User writer) {
-        this.id = id;
+        super(id, createDateTime, updateDateTime);
+
         this.comment = comment;
         this.deleted = deleted;
-        this.createDateTime = createDateTime;
-        this.updateDateTime = updateDateTime;
         this.question = question;
         this.writer = writer;
     }
@@ -91,24 +85,12 @@ public class Answer {
         }
     }
 
-    public Long getId() {
-        return id;
-    }
-
     public String getComment() {
         return comment;
     }
 
     public void delete() {
         deleted = true;
-    }
-
-    public LocalDateTime getCreateDateTime() {
-        return createDateTime;
-    }
-
-    public LocalDateTime getUpdateDateTime() {
-        return updateDateTime;
     }
 
     public Question getQuestion() {
@@ -131,16 +113,15 @@ public class Answer {
         verifyWriter(newAnswer.getWriter());
 
         this.comment = newAnswer.comment;
-        this.updateDateTime = LocalDateTime.now();
     }
 
     @Override
     public String toString() {
         return "Answer{" +
-                "id=" + id +
+                "id=" + getId() +
                 ", comment='" + comment + '\'' +
-                ", createDateTime=" + createDateTime +
-                ", updateDateTime=" + updateDateTime +
+                ", createDateTime=" + getCreateDateTime() +
+                ", updateDateTime=" + getUpdateDateTime() +
                 ", question=" + question.getId() +
                 ", writer=" + writer +
                 '}';

--- a/src/main/java/com/codessquad/qna/answer/Answer.java
+++ b/src/main/java/com/codessquad/qna/answer/Answer.java
@@ -1,9 +1,7 @@
 package com.codessquad.qna.answer;
 
-import com.codessquad.qna.common.Constant;
 import com.codessquad.qna.question.Question;
 import com.codessquad.qna.user.User;
-import com.fasterxml.jackson.annotation.JsonFormat;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
@@ -16,10 +14,7 @@ public class Answer {
 
     private String comment;
     private boolean deleted;
-
-    @JsonFormat(pattern = Constant.DEFAULT_DATE_TIME_FORMAT)
     private LocalDateTime createDateTime;
-
     private LocalDateTime updateDateTime;
 
     @ManyToOne
@@ -33,11 +28,67 @@ public class Answer {
     protected Answer() {
     }
 
-    public Answer(String comment, LocalDateTime createDateTime, Question question, User writer) {
+    public Answer(Long id, String comment, boolean deleted, LocalDateTime createDateTime, LocalDateTime updateDateTime, Question question, User writer) {
+        this.id = id;
         this.comment = comment;
-        this.createDateTime = createDateTime == null ? LocalDateTime.now() : createDateTime;
+        this.deleted = deleted;
+        this.createDateTime = createDateTime;
+        this.updateDateTime = updateDateTime;
         this.question = question;
         this.writer = writer;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private Long id;
+        private String comment;
+        private boolean deleted;
+        private LocalDateTime createDateTime;
+        private LocalDateTime updateDateTime;
+        private Question question;
+        private User writer;
+
+        public Builder setId(Long id) {
+            this.id = id;
+            return this;
+        }
+
+        public Builder setComment(String comment) {
+            this.comment = comment;
+            return this;
+        }
+
+        public Builder setDeleted(boolean deleted) {
+            this.deleted = deleted;
+            return this;
+        }
+
+        public Builder setCreateDateTime(LocalDateTime createDateTime) {
+            this.createDateTime = createDateTime;
+            return this;
+        }
+
+        public Builder setUpdateDateTime(LocalDateTime updateDateTime) {
+            this.updateDateTime = updateDateTime;
+            return this;
+        }
+
+        public Builder setQuestion(Question question) {
+            this.question = question;
+            return this;
+        }
+
+        public Builder setWriter(User writer) {
+            this.writer = writer;
+            return this;
+        }
+
+        public Answer build() {
+            return new Answer(id, comment, deleted, createDateTime, updateDateTime, question, writer);
+        }
     }
 
     public Long getId() {
@@ -70,10 +121,6 @@ public class Answer {
 
     public User getWriter() {
         return writer;
-    }
-
-    public void setWriter(User writer) {
-        this.writer = writer;
     }
 
     public void verifyWriter(User target) {

--- a/src/main/java/com/codessquad/qna/answer/Answer.java
+++ b/src/main/java/com/codessquad/qna/answer/Answer.java
@@ -75,6 +75,10 @@ public class Answer {
         writer.verifyWith(target);
     }
 
+    public boolean isWriterSameAs(User target) {
+        return writer.equals(target);
+    }
+
     public void update(Answer newAnswer) {
         verifyWriter(newAnswer.getWriter());
 

--- a/src/main/java/com/codessquad/qna/answer/AnswerController.java
+++ b/src/main/java/com/codessquad/qna/answer/AnswerController.java
@@ -1,6 +1,5 @@
 package com.codessquad.qna.answer;
 
-import com.codessquad.qna.question.Question;
 import com.codessquad.qna.utils.SessionUtils;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
@@ -17,16 +16,6 @@ public class AnswerController {
         this.answerService = answerService;
     }
 
-    @PostMapping
-    public String create(@PathVariable Long questionId, Answer answer, HttpSession session) {
-        answer.setQuestion(Question.builder().setId(questionId).build());
-        answer.setWriter(SessionUtils.getSessionUser(session).toEntity());
-
-        answerService.create(answer);
-
-        return "redirect:/questions/" + questionId;
-    }
-
     @GetMapping("/{id}/form")
     public ModelAndView viewUpdateForm(@PathVariable Long questionId, @PathVariable Long id, HttpSession session) {
         AnswerDTO result = answerService.readVerifiedAnswer(id, SessionUtils.getSessionUser(session));
@@ -35,8 +24,8 @@ public class AnswerController {
     }
 
     @PutMapping("/{id}")
-    public String update(@PathVariable Long questionId, @PathVariable Long id, Answer newAnswer, HttpSession session) {
-        newAnswer.setWriter(SessionUtils.getSessionUser(session).toEntity());
+    public String update(@PathVariable Long questionId, @PathVariable Long id, AnswerDTO newAnswer, HttpSession session) {
+        newAnswer.setWriter(SessionUtils.getSessionUser(session));
 
         answerService.update(id, newAnswer);
 

--- a/src/main/java/com/codessquad/qna/answer/AnswerController.java
+++ b/src/main/java/com/codessquad/qna/answer/AnswerController.java
@@ -29,7 +29,7 @@ public class AnswerController {
 
     @GetMapping("/{id}/form")
     public ModelAndView viewUpdateForm(@PathVariable Long questionId, @PathVariable Long id, HttpSession session) {
-        Answer result = answerService.readVerifiedAnswer(id, SessionUtils.getSessionUser(session));
+        AnswerDTO result = answerService.readVerifiedAnswer(id, SessionUtils.getSessionUser(session));
 
         return new ModelAndView("/qna/answerUpdateForm", "answer", result);
     }

--- a/src/main/java/com/codessquad/qna/answer/AnswerDTO.java
+++ b/src/main/java/com/codessquad/qna/answer/AnswerDTO.java
@@ -14,7 +14,7 @@ public class AnswerDTO {
     private String comment;
 
     @JsonFormat(pattern = Constant.DEFAULT_DATE_TIME_FORMAT)
-    private LocalDateTime createDateTime = LocalDateTime.now();
+    private LocalDateTime createDateTime;
 
     private LocalDateTime updateDateTime;
     private Long questionId;
@@ -145,6 +145,10 @@ public class AnswerDTO {
 
     public LocalDateTime getCreateDateTime() {
         return createDateTime;
+    }
+
+    public void setCreateDateTime(LocalDateTime createDateTime) {
+        this.createDateTime = createDateTime;
     }
 
     public LocalDateTime getUpdateDateTime() {

--- a/src/main/java/com/codessquad/qna/answer/AnswerDTO.java
+++ b/src/main/java/com/codessquad/qna/answer/AnswerDTO.java
@@ -1,11 +1,12 @@
 package com.codessquad.qna.answer;
 
 import com.codessquad.qna.common.Constant;
-import com.codessquad.qna.question.QuestionDTO;
 import com.codessquad.qna.user.UserDTO;
 import com.fasterxml.jackson.annotation.JsonFormat;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class AnswerDTO {
     private Long id;
@@ -15,19 +16,21 @@ public class AnswerDTO {
     private LocalDateTime createDateTime;
 
     private LocalDateTime updateDateTime;
-    private QuestionDTO question;
+    private Long questionId;
     private UserDTO writer;
+    private Integer answersCount;
 
     public AnswerDTO() {
     }
 
-    public AnswerDTO(Long id, String comment, LocalDateTime createDateTime, LocalDateTime updateDateTime, QuestionDTO question, UserDTO writer) {
+    public AnswerDTO(Long id, String comment, LocalDateTime createDateTime, LocalDateTime updateDateTime, Long questionId, UserDTO writer, Integer answersCount) {
         this.id = id;
         this.comment = comment;
         this.createDateTime = createDateTime;
         this.updateDateTime = updateDateTime;
-        this.question = question;
+        this.questionId = questionId;
         this.writer = writer;
+        this.answersCount = answersCount;
     }
 
     public static AnswerDTO from(Answer answer) {
@@ -36,9 +39,27 @@ public class AnswerDTO {
                 .setComment(answer.getComment())
                 .setCreateDateTime(answer.getCreateDateTime())
                 .setUpdateDateTime(answer.getUpdateDateTime())
-                .setQuestion(QuestionDTO.from(answer.getQuestion()))
                 .setWriter(UserDTO.from(answer.getWriter()))
+                .setQuestionId(answer.getQuestion().getId())
                 .build();
+    }
+
+    public static AnswerDTO of(Answer answer, int answersCount) {
+        return builder()
+                .setId(answer.getId())
+                .setComment(answer.getComment())
+                .setCreateDateTime(answer.getCreateDateTime())
+                .setUpdateDateTime(answer.getUpdateDateTime())
+                .setWriter(UserDTO.from(answer.getWriter()))
+                .setQuestionId(answer.getQuestion().getId())
+                .setAnswersCount(answersCount)
+                .build();
+    }
+
+    public static List<AnswerDTO> from(List<Answer> answers) {
+        return answers.stream()
+                .map(AnswerDTO::from)
+                .collect(Collectors.toList());
     }
 
     public static Builder builder() {
@@ -50,8 +71,9 @@ public class AnswerDTO {
         private String comment;
         private LocalDateTime createDateTime;
         private LocalDateTime updateDateTime;
-        private QuestionDTO question;
+        private Long questionId;
         private UserDTO writer;
+        private Integer answersCount;
 
         public Builder setId(Long id) {
             this.id = id;
@@ -73,8 +95,8 @@ public class AnswerDTO {
             return this;
         }
 
-        public Builder setQuestion(QuestionDTO question) {
-            this.question = question;
+        public Builder setQuestionId(Long questionId) {
+            this.questionId = questionId;
             return this;
         }
 
@@ -83,9 +105,15 @@ public class AnswerDTO {
             return this;
         }
 
-        public AnswerDTO build() {
-            return new AnswerDTO(id, comment, createDateTime, updateDateTime, question, writer);
+        public Builder setAnswersCount(Integer answersCount) {
+            this.answersCount = answersCount;
+            return this;
         }
+
+        public AnswerDTO build() {
+            return new AnswerDTO(id, comment, createDateTime, updateDateTime, questionId, writer, answersCount);
+        }
+
     }
 
     public Long getId() {
@@ -120,12 +148,12 @@ public class AnswerDTO {
         this.updateDateTime = updateDateTime;
     }
 
-    public QuestionDTO getQuestion() {
-        return question;
+    public Long getQuestionId() {
+        return questionId;
     }
 
-    public void setQuestion(QuestionDTO question) {
-        this.question = question;
+    public void setQuestionId(Long questionId) {
+        this.questionId = questionId;
     }
 
     public UserDTO getWriter() {
@@ -134,5 +162,13 @@ public class AnswerDTO {
 
     public void setWriter(UserDTO writer) {
         this.writer = writer;
+    }
+
+    public int getAnswersCount() {
+        return answersCount;
+    }
+
+    public void setAnswersCount(int answersCount) {
+        this.answersCount = answersCount;
     }
 }

--- a/src/main/java/com/codessquad/qna/answer/AnswerDTO.java
+++ b/src/main/java/com/codessquad/qna/answer/AnswerDTO.java
@@ -1,6 +1,7 @@
 package com.codessquad.qna.answer;
 
 import com.codessquad.qna.common.Constant;
+import com.codessquad.qna.question.Question;
 import com.codessquad.qna.user.UserDTO;
 import com.fasterxml.jackson.annotation.JsonFormat;
 
@@ -13,7 +14,7 @@ public class AnswerDTO {
     private String comment;
 
     @JsonFormat(pattern = Constant.DEFAULT_DATE_TIME_FORMAT)
-    private LocalDateTime createDateTime;
+    private LocalDateTime createDateTime = LocalDateTime.now();
 
     private LocalDateTime updateDateTime;
     private Long questionId;
@@ -64,6 +65,16 @@ public class AnswerDTO {
 
     public static Builder builder() {
         return new Builder();
+    }
+
+    public Answer toEntity() {
+        return Answer.builder()
+                .setId(id)
+                .setComment(comment)
+                .setCreateDateTime(createDateTime)
+                .setQuestion(Question.builder().setId(questionId).build())
+                .setWriter(writer.toEntity())
+                .build();
     }
 
     public static class Builder {
@@ -134,10 +145,6 @@ public class AnswerDTO {
 
     public LocalDateTime getCreateDateTime() {
         return createDateTime;
-    }
-
-    public void setCreateDateTime(LocalDateTime createDateTime) {
-        this.createDateTime = createDateTime;
     }
 
     public LocalDateTime getUpdateDateTime() {

--- a/src/main/java/com/codessquad/qna/answer/AnswerDTO.java
+++ b/src/main/java/com/codessquad/qna/answer/AnswerDTO.java
@@ -1,22 +1,15 @@
 package com.codessquad.qna.answer;
 
-import com.codessquad.qna.common.Constant;
+import com.codessquad.qna.common.BaseDTO;
 import com.codessquad.qna.question.Question;
 import com.codessquad.qna.user.UserDTO;
-import com.fasterxml.jackson.annotation.JsonFormat;
 
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class AnswerDTO {
-    private Long id;
+public class AnswerDTO extends BaseDTO {
     private String comment;
-
-    @JsonFormat(pattern = Constant.DEFAULT_DATE_TIME_FORMAT)
-    private LocalDateTime createDateTime;
-
-    private LocalDateTime updateDateTime;
     private Long questionId;
     private UserDTO writer;
     private int answersCount;
@@ -25,10 +18,9 @@ public class AnswerDTO {
     }
 
     public AnswerDTO(Long id, String comment, LocalDateTime createDateTime, LocalDateTime updateDateTime, Long questionId, UserDTO writer, int answersCount) {
-        this.id = id;
+        super(id, createDateTime, updateDateTime);
+
         this.comment = comment;
-        this.createDateTime = createDateTime;
-        this.updateDateTime = updateDateTime;
         this.questionId = questionId;
         this.writer = writer;
         this.answersCount = answersCount;
@@ -69,9 +61,9 @@ public class AnswerDTO {
 
     public Answer toEntity() {
         return Answer.builder()
-                .setId(id)
+                .setId(getId())
                 .setComment(comment)
-                .setCreateDateTime(createDateTime)
+                .setCreateDateTime(getCreateDateTime())
                 .setQuestion(Question.builder().setId(questionId).build())
                 .setWriter(writer.toEntity())
                 .build();
@@ -127,36 +119,12 @@ public class AnswerDTO {
 
     }
 
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
-
     public String getComment() {
         return comment;
     }
 
     public void setComment(String comment) {
         this.comment = comment;
-    }
-
-    public LocalDateTime getCreateDateTime() {
-        return createDateTime;
-    }
-
-    public void setCreateDateTime(LocalDateTime createDateTime) {
-        this.createDateTime = createDateTime;
-    }
-
-    public LocalDateTime getUpdateDateTime() {
-        return updateDateTime;
-    }
-
-    public void setUpdateDateTime(LocalDateTime updateDateTime) {
-        this.updateDateTime = updateDateTime;
     }
 
     public Long getQuestionId() {

--- a/src/main/java/com/codessquad/qna/answer/AnswerDTO.java
+++ b/src/main/java/com/codessquad/qna/answer/AnswerDTO.java
@@ -19,12 +19,12 @@ public class AnswerDTO {
     private LocalDateTime updateDateTime;
     private Long questionId;
     private UserDTO writer;
-    private Integer answersCount;
+    private int answersCount;
 
     public AnswerDTO() {
     }
 
-    public AnswerDTO(Long id, String comment, LocalDateTime createDateTime, LocalDateTime updateDateTime, Long questionId, UserDTO writer, Integer answersCount) {
+    public AnswerDTO(Long id, String comment, LocalDateTime createDateTime, LocalDateTime updateDateTime, Long questionId, UserDTO writer, int answersCount) {
         this.id = id;
         this.comment = comment;
         this.createDateTime = createDateTime;
@@ -84,7 +84,7 @@ public class AnswerDTO {
         private LocalDateTime updateDateTime;
         private Long questionId;
         private UserDTO writer;
-        private Integer answersCount;
+        private int answersCount;
 
         public Builder setId(Long id) {
             this.id = id;
@@ -116,7 +116,7 @@ public class AnswerDTO {
             return this;
         }
 
-        public Builder setAnswersCount(Integer answersCount) {
+        public Builder setAnswersCount(int answersCount) {
             this.answersCount = answersCount;
             return this;
         }

--- a/src/main/java/com/codessquad/qna/answer/AnswerDTO.java
+++ b/src/main/java/com/codessquad/qna/answer/AnswerDTO.java
@@ -1,0 +1,138 @@
+package com.codessquad.qna.answer;
+
+import com.codessquad.qna.common.Constant;
+import com.codessquad.qna.question.QuestionDTO;
+import com.codessquad.qna.user.UserDTO;
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.LocalDateTime;
+
+public class AnswerDTO {
+    private Long id;
+    private String comment;
+
+    @JsonFormat(pattern = Constant.DEFAULT_DATE_TIME_FORMAT)
+    private LocalDateTime createDateTime;
+
+    private LocalDateTime updateDateTime;
+    private QuestionDTO question;
+    private UserDTO writer;
+
+    public AnswerDTO() {
+    }
+
+    public AnswerDTO(Long id, String comment, LocalDateTime createDateTime, LocalDateTime updateDateTime, QuestionDTO question, UserDTO writer) {
+        this.id = id;
+        this.comment = comment;
+        this.createDateTime = createDateTime;
+        this.updateDateTime = updateDateTime;
+        this.question = question;
+        this.writer = writer;
+    }
+
+    public static AnswerDTO from(Answer answer) {
+        return builder()
+                .setId(answer.getId())
+                .setComment(answer.getComment())
+                .setCreateDateTime(answer.getCreateDateTime())
+                .setUpdateDateTime(answer.getUpdateDateTime())
+                .setQuestion(QuestionDTO.from(answer.getQuestion()))
+                .setWriter(UserDTO.from(answer.getWriter()))
+                .build();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private Long id;
+        private String comment;
+        private LocalDateTime createDateTime;
+        private LocalDateTime updateDateTime;
+        private QuestionDTO question;
+        private UserDTO writer;
+
+        public Builder setId(Long id) {
+            this.id = id;
+            return this;
+        }
+
+        public Builder setComment(String comment) {
+            this.comment = comment;
+            return this;
+        }
+
+        public Builder setCreateDateTime(LocalDateTime createDateTime) {
+            this.createDateTime = createDateTime;
+            return this;
+        }
+
+        public Builder setUpdateDateTime(LocalDateTime updateDateTime) {
+            this.updateDateTime = updateDateTime;
+            return this;
+        }
+
+        public Builder setQuestion(QuestionDTO question) {
+            this.question = question;
+            return this;
+        }
+
+        public Builder setWriter(UserDTO writer) {
+            this.writer = writer;
+            return this;
+        }
+
+        public AnswerDTO build() {
+            return new AnswerDTO(id, comment, createDateTime, updateDateTime, question, writer);
+        }
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getComment() {
+        return comment;
+    }
+
+    public void setComment(String comment) {
+        this.comment = comment;
+    }
+
+    public LocalDateTime getCreateDateTime() {
+        return createDateTime;
+    }
+
+    public void setCreateDateTime(LocalDateTime createDateTime) {
+        this.createDateTime = createDateTime;
+    }
+
+    public LocalDateTime getUpdateDateTime() {
+        return updateDateTime;
+    }
+
+    public void setUpdateDateTime(LocalDateTime updateDateTime) {
+        this.updateDateTime = updateDateTime;
+    }
+
+    public QuestionDTO getQuestion() {
+        return question;
+    }
+
+    public void setQuestion(QuestionDTO question) {
+        this.question = question;
+    }
+
+    public UserDTO getWriter() {
+        return writer;
+    }
+
+    public void setWriter(UserDTO writer) {
+        this.writer = writer;
+    }
+}

--- a/src/main/java/com/codessquad/qna/answer/AnswerRepository.java
+++ b/src/main/java/com/codessquad/qna/answer/AnswerRepository.java
@@ -6,4 +6,5 @@ import java.util.List;
 
 public interface AnswerRepository extends CrudRepository<Answer, Long> {
     List<Answer> findAllByQuestionIdAndDeletedFalse(Long questionId);
+    int countByQuestionIdAndDeletedFalse(Long questionId);
 }

--- a/src/main/java/com/codessquad/qna/answer/AnswerRepository.java
+++ b/src/main/java/com/codessquad/qna/answer/AnswerRepository.java
@@ -1,10 +1,11 @@
 package com.codessquad.qna.answer;
 
+import com.codessquad.qna.question.Question;
 import org.springframework.data.repository.CrudRepository;
 
 import java.util.List;
 
 public interface AnswerRepository extends CrudRepository<Answer, Long> {
     List<Answer> findAllByQuestionIdAndDeletedFalse(Long questionId);
-    int countByQuestionIdAndDeletedFalse(Long questionId);
+    int countByQuestionAndDeletedFalse(Question question);
 }

--- a/src/main/java/com/codessquad/qna/answer/AnswerRepository.java
+++ b/src/main/java/com/codessquad/qna/answer/AnswerRepository.java
@@ -2,5 +2,8 @@ package com.codessquad.qna.answer;
 
 import org.springframework.data.repository.CrudRepository;
 
+import java.util.List;
+
 public interface AnswerRepository extends CrudRepository<Answer, Long> {
+    List<Answer> findAllByQuestionIdAndDeletedFalse(Long questionId);
 }

--- a/src/main/java/com/codessquad/qna/answer/AnswerService.java
+++ b/src/main/java/com/codessquad/qna/answer/AnswerService.java
@@ -31,8 +31,8 @@ public class AnswerService {
         return answer;
     }
 
-    public void create(Answer answer) {
-        answerRepository.save(answer);
+    public Answer create(Answer answer) {
+        return answerRepository.save(answer);
     }
 
     public void update(Long id, Answer newAnswer) {

--- a/src/main/java/com/codessquad/qna/answer/AnswerService.java
+++ b/src/main/java/com/codessquad/qna/answer/AnswerService.java
@@ -14,6 +14,10 @@ public class AnswerService {
         this.answerRepository = answerRepository;
     }
 
+    public List<Answer> readAll(Long questionId) {
+        return answerRepository.findAllByQuestionIdAndDeletedFalse(questionId);
+    }
+
     private Answer read(Long id) {
         return answerRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("존재하지 않는 답변입니다. id : " + id));
@@ -38,13 +42,18 @@ public class AnswerService {
         answerRepository.save(existedAnswer);
     }
 
-    public void delete(List<Answer> answers) {
-        answerRepository.deleteAll(answers);
+    public void deleteAll(List<Answer> answers) {
+        for (Answer answer : answers) {
+            answer.delete();
+        }
+
+        answerRepository.saveAll(answers);
     }
 
     public void delete(Long id, UserDTO currentSessionUser) {
         Answer answer = readVerifiedAnswer(id, currentSessionUser);
+        answer.delete();
 
-        answerRepository.delete(answer);
+        answerRepository.save(answer);
     }
 }

--- a/src/main/java/com/codessquad/qna/answer/AnswerService.java
+++ b/src/main/java/com/codessquad/qna/answer/AnswerService.java
@@ -35,8 +35,8 @@ public class AnswerService {
         return AnswerDTO.from(answer);
     }
 
-    public AnswerDTO create(Answer answer) {
-        Answer savedAnswer = answerRepository.save(answer);
+    public AnswerDTO create(AnswerDTO answer) {
+        Answer savedAnswer = answerRepository.save(answer.toEntity());
 
         int answersCount = countBy(savedAnswer.getQuestion().getId());
         AnswerDTO result = AnswerDTO.of(savedAnswer, answersCount);
@@ -44,11 +44,11 @@ public class AnswerService {
         return result;
     }
 
-    public void update(Long id, Answer newAnswer) {
+    public void update(Long id, AnswerDTO newAnswer) {
         Answer existedAnswer = answerRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("존재하지 않는 답변입니다. id : " + id));
 
-        existedAnswer.update(newAnswer);
+        existedAnswer.update(newAnswer.toEntity());
         answerRepository.save(existedAnswer);
     }
 

--- a/src/main/java/com/codessquad/qna/answer/AnswerService.java
+++ b/src/main/java/com/codessquad/qna/answer/AnswerService.java
@@ -21,14 +21,13 @@ public class AnswerService {
                 .collect(Collectors.toList());
     }
 
-    private AnswerDTO read(Long id) {
-        return AnswerDTO.from(answerRepository.findById(id)
-                .orElseThrow(() -> new ResourceNotFoundException("존재하지 않는 답변입니다. id : " + id)));
+    private Answer readExistedAnswer(Long id) {
+        return answerRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("존재하지 않는 답변입니다. id : " + id));
     }
 
     public AnswerDTO readVerifiedAnswer(Long id, UserDTO user) {
-        Answer answer = answerRepository.findById(id)
-                .orElseThrow(() -> new ResourceNotFoundException("존재하지 않는 답변입니다. id : " + id));
+        Answer answer = readExistedAnswer(id);
 
         answer.verifyWriter(user.toEntity());
 
@@ -45,8 +44,7 @@ public class AnswerService {
     }
 
     public void update(Long id, AnswerDTO newAnswer) {
-        Answer existedAnswer = answerRepository.findById(id)
-                .orElseThrow(() -> new ResourceNotFoundException("존재하지 않는 답변입니다. id : " + id));
+        Answer existedAnswer = readExistedAnswer(id);
 
         existedAnswer.update(newAnswer.toEntity());
         answerRepository.save(existedAnswer);
@@ -61,8 +59,7 @@ public class AnswerService {
     }
 
     public AnswerDTO delete(Long id, UserDTO currentSessionUser) {
-        Answer answer = answerRepository.findById(id)
-                .orElseThrow(() -> new ResourceNotFoundException("존재하지 않는 답변입니다. id : " + id));
+        Answer answer = readExistedAnswer(id);
 
         answer.verifyWriter(currentSessionUser.toEntity());
         answer.delete();
@@ -72,7 +69,7 @@ public class AnswerService {
         return AnswerDTO.of(answerRepository.save(answer), answersCount);
     }
 
-    public int countBy(Long questionId) {
+    private int countBy(Long questionId) {
         return answerRepository.countByQuestionIdAndDeletedFalse(questionId);
     }
 }

--- a/src/main/java/com/codessquad/qna/answer/AnswerService.java
+++ b/src/main/java/com/codessquad/qna/answer/AnswerService.java
@@ -69,7 +69,7 @@ public class AnswerService {
         return AnswerDTO.of(deletedAnswer, countBy(deletedAnswer.getQuestion()));
     }
 
-    private int countBy(Question question) {
+    public int countBy(Question question) {
         return answerRepository.countByQuestionAndDeletedFalse(question);
     }
 }

--- a/src/main/java/com/codessquad/qna/answer/AnswerService.java
+++ b/src/main/java/com/codessquad/qna/answer/AnswerService.java
@@ -1,6 +1,7 @@
 package com.codessquad.qna.answer;
 
 import com.codessquad.qna.exception.ResourceNotFoundException;
+import com.codessquad.qna.question.Question;
 import com.codessquad.qna.user.UserDTO;
 import org.springframework.stereotype.Service;
 
@@ -37,7 +38,7 @@ public class AnswerService {
     public AnswerDTO create(AnswerDTO answer) {
         Answer savedAnswer = answerRepository.save(answer.toEntity());
 
-        int answersCount = countBy(savedAnswer.getQuestion().getId());
+        int answersCount = countBy(savedAnswer.getQuestion());
         AnswerDTO result = AnswerDTO.of(savedAnswer, answersCount);
 
         return result;
@@ -65,11 +66,10 @@ public class AnswerService {
         answer.delete();
         Answer deletedAnswer = answerRepository.save(answer);
 
-        int answersCount = countBy(deletedAnswer.getQuestion().getId());
-        return AnswerDTO.of(answerRepository.save(answer), answersCount);
+        return AnswerDTO.of(deletedAnswer, countBy(deletedAnswer.getQuestion()));
     }
 
-    private int countBy(Long questionId) {
-        return answerRepository.countByQuestionIdAndDeletedFalse(questionId);
+    private int countBy(Question question) {
+        return answerRepository.countByQuestionAndDeletedFalse(question);
     }
 }

--- a/src/main/java/com/codessquad/qna/answer/AnswerService.java
+++ b/src/main/java/com/codessquad/qna/answer/AnswerService.java
@@ -50,10 +50,10 @@ public class AnswerService {
         answerRepository.saveAll(answers);
     }
 
-    public void delete(Long id, UserDTO currentSessionUser) {
+    public Answer delete(Long id, UserDTO currentSessionUser) {
         Answer answer = readVerifiedAnswer(id, currentSessionUser);
         answer.delete();
 
-        answerRepository.save(answer);
+        return answerRepository.save(answer);
     }
 }

--- a/src/main/java/com/codessquad/qna/answer/ApiAnswerController.java
+++ b/src/main/java/com/codessquad/qna/answer/ApiAnswerController.java
@@ -1,11 +1,9 @@
 package com.codessquad.qna.answer;
 
 import com.codessquad.qna.question.Question;
+import com.codessquad.qna.question.QuestionService;
 import com.codessquad.qna.utils.SessionUtils;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpSession;
 
@@ -13,9 +11,11 @@ import javax.servlet.http.HttpSession;
 @RequestMapping("/api/questions/{questionId}/answers")
 public class ApiAnswerController {
     private final AnswerService answerService;
+    private final QuestionService questionService;
 
-    public ApiAnswerController(AnswerService answerService) {
+    public ApiAnswerController(AnswerService answerService, QuestionService questionService) {
         this.answerService = answerService;
+        this.questionService = questionService;
     }
 
     @PostMapping
@@ -24,5 +24,15 @@ public class ApiAnswerController {
         answer.setWriter(SessionUtils.getSessionUser(session).toEntity());
 
         return answerService.create(answer);
+    }
+
+    @DeleteMapping("/{id}")
+    public AnswerDTO delete(@PathVariable Long questionId, @PathVariable Long id, HttpSession session) {
+        Answer result = answerService.delete(id, SessionUtils.getSessionUser(session));
+        Question question = questionService.read(questionId);
+
+        result.setQuestion(question);
+
+        return AnswerDTO.from(result);
     }
 }

--- a/src/main/java/com/codessquad/qna/answer/ApiAnswerController.java
+++ b/src/main/java/com/codessquad/qna/answer/ApiAnswerController.java
@@ -19,20 +19,19 @@ public class ApiAnswerController {
     }
 
     @PostMapping
-    public Answer create(@PathVariable Long questionId, Answer answer, HttpSession session) {
+    public AnswerDTO create(@PathVariable Long questionId, Answer answer, HttpSession session) {
         answer.setQuestion(Question.builder().setId(questionId).build());
         answer.setWriter(SessionUtils.getSessionUser(session).toEntity());
 
-        return answerService.create(answer);
+        AnswerDTO result = answerService.create(answer);
+
+        return result;
     }
 
     @DeleteMapping("/{id}")
     public AnswerDTO delete(@PathVariable Long questionId, @PathVariable Long id, HttpSession session) {
-        Answer result = answerService.delete(id, SessionUtils.getSessionUser(session));
-        Question question = questionService.read(questionId);
+        AnswerDTO result = answerService.delete(id, SessionUtils.getSessionUser(session));
 
-        result.setQuestion(question);
-
-        return AnswerDTO.from(result);
+        return result;
     }
 }

--- a/src/main/java/com/codessquad/qna/answer/ApiAnswerController.java
+++ b/src/main/java/com/codessquad/qna/answer/ApiAnswerController.java
@@ -1,0 +1,28 @@
+package com.codessquad.qna.answer;
+
+import com.codessquad.qna.question.Question;
+import com.codessquad.qna.utils.SessionUtils;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpSession;
+
+@RestController
+@RequestMapping("/api/questions/{questionId}/answers")
+public class ApiAnswerController {
+    private final AnswerService answerService;
+
+    public ApiAnswerController(AnswerService answerService) {
+        this.answerService = answerService;
+    }
+
+    @PostMapping
+    public Answer create(@PathVariable Long questionId, Answer answer, HttpSession session) {
+        answer.setQuestion(Question.builder().setId(questionId).build());
+        answer.setWriter(SessionUtils.getSessionUser(session).toEntity());
+
+        return answerService.create(answer);
+    }
+}

--- a/src/main/java/com/codessquad/qna/answer/ApiAnswerController.java
+++ b/src/main/java/com/codessquad/qna/answer/ApiAnswerController.java
@@ -1,6 +1,5 @@
 package com.codessquad.qna.answer;
 
-import com.codessquad.qna.question.Question;
 import com.codessquad.qna.question.QuestionService;
 import com.codessquad.qna.utils.SessionUtils;
 import org.springframework.web.bind.annotation.*;
@@ -11,17 +10,15 @@ import javax.servlet.http.HttpSession;
 @RequestMapping("/api/questions/{questionId}/answers")
 public class ApiAnswerController {
     private final AnswerService answerService;
-    private final QuestionService questionService;
 
-    public ApiAnswerController(AnswerService answerService, QuestionService questionService) {
+    public ApiAnswerController(AnswerService answerService) {
         this.answerService = answerService;
-        this.questionService = questionService;
     }
 
     @PostMapping
-    public AnswerDTO create(@PathVariable Long questionId, Answer answer, HttpSession session) {
-        answer.setQuestion(Question.builder().setId(questionId).build());
-        answer.setWriter(SessionUtils.getSessionUser(session).toEntity());
+    public AnswerDTO create(@PathVariable Long questionId, AnswerDTO answer, HttpSession session) {
+        answer.setQuestionId(questionId);
+        answer.setWriter(SessionUtils.getSessionUser(session));
 
         AnswerDTO result = answerService.create(answer);
 

--- a/src/main/java/com/codessquad/qna/answer/ApiAnswerController.java
+++ b/src/main/java/com/codessquad/qna/answer/ApiAnswerController.java
@@ -1,6 +1,5 @@
 package com.codessquad.qna.answer;
 
-import com.codessquad.qna.question.QuestionService;
 import com.codessquad.qna.utils.SessionUtils;
 import org.springframework.web.bind.annotation.*;
 

--- a/src/main/java/com/codessquad/qna/common/BaseDTO.java
+++ b/src/main/java/com/codessquad/qna/common/BaseDTO.java
@@ -1,0 +1,52 @@
+package com.codessquad.qna.common;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.LocalDateTime;
+
+public class BaseDTO {
+    private Long id;
+
+    @JsonFormat(pattern = Constant.DEFAULT_DATE_TIME_FORMAT)
+    private LocalDateTime createDateTime;
+
+    @JsonFormat(pattern = Constant.DEFAULT_DATE_TIME_FORMAT)
+    private LocalDateTime updateDateTime;
+
+    protected BaseDTO() {
+    }
+
+    protected BaseDTO(Long id) {
+        this.id = id;
+    }
+
+    protected BaseDTO(Long id, LocalDateTime createDateTime, LocalDateTime updateDateTime) {
+        this.id = id;
+        this.createDateTime = createDateTime;
+        this.updateDateTime = updateDateTime;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public LocalDateTime getCreateDateTime() {
+        return createDateTime;
+    }
+
+    public void setCreateDateTime(LocalDateTime createDateTime) {
+        this.createDateTime = createDateTime;
+    }
+
+    public LocalDateTime getUpdateDateTime() {
+        return updateDateTime;
+    }
+
+    public void setUpdateDateTime(LocalDateTime updateDateTime) {
+        this.updateDateTime = updateDateTime;
+    }
+}

--- a/src/main/java/com/codessquad/qna/common/BaseDTO.java
+++ b/src/main/java/com/codessquad/qna/common/BaseDTO.java
@@ -38,6 +38,14 @@ public class BaseDTO {
         return createDateTime;
     }
 
+    public String getFormattedDateTime() {
+        if (createDateTime == null) {
+            return "";
+        }
+
+        return createDateTime.format(Constant.DEFAULT_DATE_TIME_FORMATTER);
+    }
+
     public void setCreateDateTime(LocalDateTime createDateTime) {
         this.createDateTime = createDateTime;
     }

--- a/src/main/java/com/codessquad/qna/common/BaseEntity.java
+++ b/src/main/java/com/codessquad/qna/common/BaseEntity.java
@@ -1,0 +1,47 @@
+package com.codessquad.qna.common;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @CreatedDate
+    private LocalDateTime createDateTime;
+
+    @LastModifiedDate
+    private LocalDateTime updateDateTime;
+
+    protected BaseEntity() {
+    }
+
+    protected BaseEntity(Long id) {
+        this.id = id;
+    }
+
+    protected BaseEntity(Long id, LocalDateTime createDateTime, LocalDateTime updateDateTime) {
+        this.id = id;
+        this.createDateTime = createDateTime;
+        this.updateDateTime = updateDateTime;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public LocalDateTime getCreateDateTime() {
+        return createDateTime;
+    }
+
+    public LocalDateTime getUpdateDateTime() {
+        return updateDateTime;
+    }
+}

--- a/src/main/java/com/codessquad/qna/common/Constant.java
+++ b/src/main/java/com/codessquad/qna/common/Constant.java
@@ -3,7 +3,8 @@ package com.codessquad.qna.common;
 import java.time.format.DateTimeFormatter;
 
 public class Constant {
-    public static final DateTimeFormatter DEFAULT_DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+    public static final String DEFAULT_DATE_TIME_FORMAT = "yyyy-MM-dd HH:mm";
+    public static final DateTimeFormatter DEFAULT_DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern(DEFAULT_DATE_TIME_FORMAT);
 
     private Constant() {
     }

--- a/src/main/java/com/codessquad/qna/common/DummyDataFactory.java
+++ b/src/main/java/com/codessquad/qna/common/DummyDataFactory.java
@@ -59,6 +59,10 @@ public class DummyDataFactory {
                 new Answer("국내에서 Ruby on Rails와 Play가 활성화되기 힘든 이유는 뭘까",
                         LocalDateTime.of(2016, 1, 15, 18, 47),
                         Question.builder().setId(1L).build(),
+                        User.builder().setId(1L).build()),
+                new Answer("국내에서 Ruby on Rails와 Play가 활성화되기 힘든 이유는 뭘까",
+                        LocalDateTime.of(2016, 1, 15, 18, 47),
+                        Question.builder().setId(5L).build(),
                         User.builder().setId(1L).build())
         );
     }

--- a/src/main/java/com/codessquad/qna/common/DummyDataFactory.java
+++ b/src/main/java/com/codessquad/qna/common/DummyDataFactory.java
@@ -44,26 +44,36 @@ public class DummyDataFactory {
 
     public static List<Answer> createAnswers() {
         return Arrays.asList(
-                new Answer("국내에서 Ruby on Rails와 Play가 활성화되기 힘든 이유는 뭘까",
-                        LocalDateTime.of(2016, 1, 15, 18, 47),
-                        Question.builder().setId(1L).build(),
-                        User.builder().setId(1L).build()),
-                new Answer("국내에서 Ruby on Rails와 Play가 활성화되기 힘든 이유는 뭘까",
-                        LocalDateTime.of(2016, 1, 15, 18, 47),
-                        Question.builder().setId(2L).build(),
-                        User.builder().setId(2L).build()),
-                new Answer("국내에서 Ruby on Rails와 Play가 활성화되기 힘든 이유는 뭘까",
-                        LocalDateTime.of(2016, 1, 15, 18, 47),
-                        Question.builder().setId(3L).build(),
-                        User.builder().setId(4L).build()),
-                new Answer("국내에서 Ruby on Rails와 Play가 활성화되기 힘든 이유는 뭘까",
-                        LocalDateTime.of(2016, 1, 15, 18, 47),
-                        Question.builder().setId(1L).build(),
-                        User.builder().setId(1L).build()),
-                new Answer("국내에서 Ruby on Rails와 Play가 활성화되기 힘든 이유는 뭘까",
-                        LocalDateTime.of(2016, 1, 15, 18, 47),
-                        Question.builder().setId(5L).build(),
-                        User.builder().setId(1L).build())
+                Answer.builder()
+                        .setComment("국내에서 Ruby on Rails와 Play가 활성화되기 힘든 이유는 뭘까")
+                        .setCreateDateTime(LocalDateTime.of(2016, 1, 15, 18, 47))
+                        .setQuestion(Question.builder().setId(1L).build())
+                        .setWriter(User.builder().setId(1L).build())
+                        .build(),
+                Answer.builder()
+                        .setComment("국내에서 Ruby on Rails와 Play가 활성화되기 힘든 이유는 뭘까")
+                        .setCreateDateTime(LocalDateTime.of(2016, 1, 15, 18, 47))
+                        .setQuestion(Question.builder().setId(2L).build())
+                        .setWriter(User.builder().setId(2L).build())
+                        .build(),
+                Answer.builder()
+                        .setComment("국내에서 Ruby on Rails와 Play가 활성화되기 힘든 이유는 뭘까")
+                        .setCreateDateTime(LocalDateTime.of(2016, 1, 15, 18, 47))
+                        .setQuestion(Question.builder().setId(3L).build())
+                        .setWriter(User.builder().setId(4L).build())
+                        .build(),
+                Answer.builder()
+                        .setComment("국내에서 Ruby on Rails와 Play가 활성화되기 힘든 이유는 뭘까")
+                        .setCreateDateTime(LocalDateTime.of(2016, 1, 15, 18, 47))
+                        .setQuestion(Question.builder().setId(1L).build())
+                        .setWriter(User.builder().setId(1L).build())
+                        .build(),
+                Answer.builder()
+                        .setComment("국내에서 Ruby on Rails와 Play가 활성화되기 힘든 이유는 뭘까")
+                        .setCreateDateTime(LocalDateTime.of(2016, 1, 15, 18, 47))
+                        .setQuestion(Question.builder().setId(5L).build())
+                        .setWriter(User.builder().setId(1L).build())
+                        .build()
         );
     }
 

--- a/src/main/java/com/codessquad/qna/config/CustomHandlebarsHelper.java
+++ b/src/main/java/com/codessquad/qna/config/CustomHandlebarsHelper.java
@@ -1,18 +1,12 @@
 package com.codessquad.qna.config;
 
-import com.codessquad.qna.common.Constant;
 import com.github.jknack.handlebars.Options;
 import pl.allegro.tech.boot.autoconfigure.handlebars.HandlebarsHelper;
 
 import java.io.IOException;
-import java.time.LocalDateTime;
 
 @HandlebarsHelper
 public class CustomHandlebarsHelper {
-
-    public String formatDateTime(LocalDateTime date) {
-        return date.format(Constant.DEFAULT_DATE_TIME_FORMATTER);
-    }
 
     public Object ifEquals(Object s1, Object s2, Options options) throws IOException {
         Options.Buffer buffer = options.buffer();

--- a/src/main/java/com/codessquad/qna/exception/InsufficientAuthenticationException.java
+++ b/src/main/java/com/codessquad/qna/exception/InsufficientAuthenticationException.java
@@ -1,7 +1,13 @@
 package com.codessquad.qna.exception;
 
 public class InsufficientAuthenticationException extends RuntimeException {
+
+    public InsufficientAuthenticationException(String message) {
+        super(message);
+    }
+
     public InsufficientAuthenticationException(String message, Throwable e) {
         super(message, e);
     }
+
 }

--- a/src/main/java/com/codessquad/qna/question/Question.java
+++ b/src/main/java/com/codessquad/qna/question/Question.java
@@ -19,6 +19,7 @@ public class Question {
     @Column(nullable = false, length = 5000)
     private String contents;
 
+    private boolean deleted;
     private LocalDateTime createDateTime;
     private LocalDateTime updateDateTime;
 
@@ -105,6 +106,10 @@ public class Question {
 
     public String getContents() {
         return contents;
+    }
+
+    public void delete() {
+        deleted = true;
     }
 
     public LocalDateTime getCreateDateTime() {

--- a/src/main/java/com/codessquad/qna/question/Question.java
+++ b/src/main/java/com/codessquad/qna/question/Question.java
@@ -1,6 +1,7 @@
 package com.codessquad.qna.question;
 
 import com.codessquad.qna.answer.Answer;
+import com.codessquad.qna.common.BaseEntity;
 import com.codessquad.qna.exception.InsufficientAuthenticationException;
 import com.codessquad.qna.user.User;
 
@@ -9,11 +10,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 @Entity
-public class Question {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-
+public class Question extends BaseEntity {
     @Column(nullable = false, length = 100)
     private String title;
 
@@ -21,8 +18,6 @@ public class Question {
     private String contents;
 
     private boolean deleted;
-    private LocalDateTime createDateTime;
-    private LocalDateTime updateDateTime;
 
     @ManyToOne
     @JoinColumn(foreignKey = @ForeignKey(name = "fk_question_writer"))
@@ -35,11 +30,10 @@ public class Question {
     }
 
     public Question(Long id, String title, String contents, LocalDateTime createDateTime, LocalDateTime updateDateTime, User writer, List<Answer> answers) {
-        this.id = id;
+        super(id, createDateTime, updateDateTime);
+
         this.title = title;
         this.contents = contents;
-        this.createDateTime = createDateTime == null ? LocalDateTime.now() : createDateTime;
-        this.updateDateTime = updateDateTime;
         this.writer = writer;
         this.answers = answers;
     }
@@ -97,10 +91,6 @@ public class Question {
         }
     }
 
-    public Long getId() {
-        return id;
-    }
-
     public String getTitle() {
         return title;
     }
@@ -113,28 +103,12 @@ public class Question {
         deleted = true;
     }
 
-    public LocalDateTime getCreateDateTime() {
-        return createDateTime;
-    }
-
-    public LocalDateTime getUpdateDateTime() {
-        return updateDateTime;
-    }
-
     public User getWriter() {
         return writer;
     }
 
-    public void setWriter(User writer) {
-        this.writer = writer;
-    }
-
     public List<Answer> getAnswers() {
         return answers;
-    }
-
-    public void setAnswers(List<Answer> answers) {
-        this.answers = answers;
     }
 
     public void verifyWriter(User target) {
@@ -159,17 +133,16 @@ public class Question {
 
         this.title = newQuestion.title;
         this.contents = newQuestion.contents;
-        this.updateDateTime = LocalDateTime.now();
     }
 
     @Override
     public String toString() {
         return "Question{" +
-                "id=" + id +
+                "id=" + getId() +
                 ", title='" + title + '\'' +
                 ", contents='" + contents + '\'' +
-                ", createDateTime=" + createDateTime +
-                ", updateDateTime=" + updateDateTime +
+                ", createDateTime=" + getCreateDateTime() +
+                ", updateDateTime=" + getUpdateDateTime() +
                 ", writer=" + writer +
                 ", answers=" + answers +
                 '}';

--- a/src/main/java/com/codessquad/qna/question/Question.java
+++ b/src/main/java/com/codessquad/qna/question/Question.java
@@ -1,6 +1,7 @@
 package com.codessquad.qna.question;
 
 import com.codessquad.qna.answer.Answer;
+import com.codessquad.qna.exception.InsufficientAuthenticationException;
 import com.codessquad.qna.user.User;
 
 import javax.persistence.*;
@@ -142,6 +143,15 @@ public class Question {
 
     public boolean isWriterDifferentFrom(Answer answer) {
         return !answer.isWriterSameAs(writer);
+    }
+
+    public void checkDeletable(User writer) {
+        verifyWriter(writer);
+
+        boolean differentWriterExists = answers.stream().anyMatch(this::isWriterDifferentFrom);
+        if (differentWriterExists) {
+            throw new InsufficientAuthenticationException("다른 작성자가 작성한 답변이 있으면 삭제할 수 없습니다.");
+        }
     }
 
     public void update(Question newQuestion) {

--- a/src/main/java/com/codessquad/qna/question/Question.java
+++ b/src/main/java/com/codessquad/qna/question/Question.java
@@ -140,6 +140,10 @@ public class Question {
         writer.verifyWith(target);
     }
 
+    public boolean isWriterDifferentFrom(Answer answer) {
+        return !answer.isWriterSameAs(writer);
+    }
+
     public void update(Question newQuestion) {
         verifyWriter(newQuestion.getWriter());
 

--- a/src/main/java/com/codessquad/qna/question/QuestionController.java
+++ b/src/main/java/com/codessquad/qna/question/QuestionController.java
@@ -37,7 +37,7 @@ public class QuestionController {
 
     @GetMapping("/{id}/form")
     public ModelAndView viewUpdateForm(@PathVariable Long id, HttpSession session) {
-        Question result = questionService.readVerifiedQuestion(id, SessionUtils.getSessionUser(session)).toEntity();
+        QuestionDTO result = questionService.readVerifiedQuestion(id, SessionUtils.getSessionUser(session));
 
         return new ModelAndView("/qna/updateForm", "question", result);
     }

--- a/src/main/java/com/codessquad/qna/question/QuestionController.java
+++ b/src/main/java/com/codessquad/qna/question/QuestionController.java
@@ -22,8 +22,8 @@ public class QuestionController {
     }
 
     @PostMapping
-    public String create(Question question, HttpSession session) {
-        question.setWriter(SessionUtils.getSessionUser(session).toEntity());
+    public String create(QuestionDTO question, HttpSession session) {
+        question.setWriter(SessionUtils.getSessionUser(session));
 
         questionService.create(question);
 
@@ -37,14 +37,14 @@ public class QuestionController {
 
     @GetMapping("/{id}/form")
     public ModelAndView viewUpdateForm(@PathVariable Long id, HttpSession session) {
-        Question result = questionService.readVerifiedQuestion(id, SessionUtils.getSessionUser(session));
+        Question result = questionService.readVerifiedQuestion(id, SessionUtils.getSessionUser(session)).toEntity();
 
         return new ModelAndView("/qna/updateForm", "question", result);
     }
 
     @PutMapping("/{id}")
-    public String update(@PathVariable Long id, Question newQuestion, HttpSession session) {
-        newQuestion.setWriter(SessionUtils.getSessionUser(session).toEntity());
+    public String update(@PathVariable Long id, QuestionDTO newQuestion, HttpSession session) {
+        newQuestion.setWriter(SessionUtils.getSessionUser(session));
 
         questionService.update(id, newQuestion);
 

--- a/src/main/java/com/codessquad/qna/question/QuestionDTO.java
+++ b/src/main/java/com/codessquad/qna/question/QuestionDTO.java
@@ -49,6 +49,19 @@ public class QuestionDTO {
                 .build();
     }
 
+    public static QuestionDTO of(Question question, List<AnswerDTO> answers) {
+        return builder()
+                .setId(question.getId())
+                .setTitle(question.getTitle())
+                .setContents(question.getContents())
+                .setCreateDateTime(question.getCreateDateTime())
+                .setUpdateDateTime(question.getUpdateDateTime())
+                .setWriter(UserDTO.from(question.getWriter()))
+                .setAnswers(answers)
+                .setAnswersCount(answers.size())
+                .build();
+    }
+
     public static QuestionDTO of(Question question, int answersCount) {
         return builder()
                 .setId(question.getId())

--- a/src/main/java/com/codessquad/qna/question/QuestionDTO.java
+++ b/src/main/java/com/codessquad/qna/question/QuestionDTO.java
@@ -1,10 +1,12 @@
 package com.codessquad.qna.question;
 
+import com.codessquad.qna.answer.AnswerDTO;
 import com.codessquad.qna.common.Constant;
 import com.codessquad.qna.user.UserDTO;
 import com.fasterxml.jackson.annotation.JsonFormat;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class QuestionDTO {
     private Long id;
@@ -16,19 +18,21 @@ public class QuestionDTO {
 
     private LocalDateTime updateDateTime;
     private UserDTO writer;
-    private int answerCount;
+    private List<AnswerDTO> answers;
+    private int answersCount;
 
     public QuestionDTO() {
     }
 
-    public QuestionDTO(Long id, String title, String contents, LocalDateTime createDateTime, LocalDateTime updateDateTime, UserDTO writer, int answerCount) {
+    public QuestionDTO(Long id, String title, String contents, LocalDateTime createDateTime, LocalDateTime updateDateTime, UserDTO writer, List<AnswerDTO> answers, int answersCount) {
         this.id = id;
         this.title = title;
         this.contents = contents;
         this.createDateTime = createDateTime;
         this.updateDateTime = updateDateTime;
         this.writer = writer;
-        this.answerCount = answerCount;
+        this.answers = answers;
+        this.answersCount = answersCount;
     }
 
     public static QuestionDTO from(Question question) {
@@ -39,13 +43,15 @@ public class QuestionDTO {
                 .setCreateDateTime(question.getCreateDateTime())
                 .setUpdateDateTime(question.getUpdateDateTime())
                 .setWriter(UserDTO.from(question.getWriter()))
-                .setAnswerCount(question.getAnswers().size())
+                .setAnswers(AnswerDTO.from(question.getAnswers()))
+                .setAnswersCount(question.getAnswers() != null ? question.getAnswers().size() : 0)
                 .build();
     }
 
     public static Builder builder() {
         return new Builder();
     }
+
 
     public static class Builder {
         private Long id;
@@ -54,7 +60,8 @@ public class QuestionDTO {
         private LocalDateTime createDateTime;
         private LocalDateTime updateDateTime;
         private UserDTO writer;
-        private int answerCount;
+        private List<AnswerDTO> answers;
+        private int answersCount;
 
         public Builder setId(Long id) {
             this.id = id;
@@ -86,13 +93,18 @@ public class QuestionDTO {
             return this;
         }
 
-        public Builder setAnswerCount(int answerCount) {
-            this.answerCount = answerCount;
+        public Builder setAnswers(List<AnswerDTO> answers) {
+            this.answers = answers;
+            return this;
+        }
+
+        public Builder setAnswersCount(int answersCount) {
+            this.answersCount = answersCount;
             return this;
         }
 
         public QuestionDTO build() {
-            return new QuestionDTO(id, title, contents, createDateTime, updateDateTime, writer, answerCount);
+            return new QuestionDTO(id, title, contents, createDateTime, updateDateTime, writer, answers, answersCount);
         }
     }
 
@@ -144,11 +156,19 @@ public class QuestionDTO {
         this.writer = writer;
     }
 
-    public int getAnswerCount() {
-        return answerCount;
+    public List<AnswerDTO> getAnswers() {
+        return answers;
     }
 
-    public void setAnswerCount(int answerCount) {
-        this.answerCount = answerCount;
+    public void setAnswers(List<AnswerDTO> answers) {
+        this.answers = answers;
+    }
+
+    public int getAnswersCount() {
+        return answersCount;
+    }
+
+    public void setAnswersCount(int answersCount) {
+        this.answersCount = answersCount;
     }
 }

--- a/src/main/java/com/codessquad/qna/question/QuestionDTO.java
+++ b/src/main/java/com/codessquad/qna/question/QuestionDTO.java
@@ -1,0 +1,154 @@
+package com.codessquad.qna.question;
+
+import com.codessquad.qna.common.Constant;
+import com.codessquad.qna.user.UserDTO;
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.LocalDateTime;
+
+public class QuestionDTO {
+    private Long id;
+    private String title;
+    private String contents;
+
+    @JsonFormat(pattern = Constant.DEFAULT_DATE_TIME_FORMAT)
+    private LocalDateTime createDateTime;
+
+    private LocalDateTime updateDateTime;
+    private UserDTO writer;
+    private int answerCount;
+
+    public QuestionDTO() {
+    }
+
+    public QuestionDTO(Long id, String title, String contents, LocalDateTime createDateTime, LocalDateTime updateDateTime, UserDTO writer, int answerCount) {
+        this.id = id;
+        this.title = title;
+        this.contents = contents;
+        this.createDateTime = createDateTime;
+        this.updateDateTime = updateDateTime;
+        this.writer = writer;
+        this.answerCount = answerCount;
+    }
+
+    public static QuestionDTO from(Question question) {
+        return builder()
+                .setId(question.getId())
+                .setTitle(question.getTitle())
+                .setContents(question.getContents())
+                .setCreateDateTime(question.getCreateDateTime())
+                .setUpdateDateTime(question.getUpdateDateTime())
+                .setWriter(UserDTO.from(question.getWriter()))
+                .setAnswerCount(question.getAnswers().size())
+                .build();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private Long id;
+        private String title;
+        private String contents;
+        private LocalDateTime createDateTime;
+        private LocalDateTime updateDateTime;
+        private UserDTO writer;
+        private int answerCount;
+
+        public Builder setId(Long id) {
+            this.id = id;
+            return this;
+        }
+
+        public Builder setTitle(String title) {
+            this.title = title;
+            return this;
+        }
+
+        public Builder setContents(String contents) {
+            this.contents = contents;
+            return this;
+        }
+
+        public Builder setCreateDateTime(LocalDateTime createDateTime) {
+            this.createDateTime = createDateTime;
+            return this;
+        }
+
+        public Builder setUpdateDateTime(LocalDateTime updateDateTime) {
+            this.updateDateTime = updateDateTime;
+            return this;
+        }
+
+        public Builder setWriter(UserDTO writer) {
+            this.writer = writer;
+            return this;
+        }
+
+        public Builder setAnswerCount(int answerCount) {
+            this.answerCount = answerCount;
+            return this;
+        }
+
+        public QuestionDTO build() {
+            return new QuestionDTO(id, title, contents, createDateTime, updateDateTime, writer, answerCount);
+        }
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getContents() {
+        return contents;
+    }
+
+    public void setContents(String contents) {
+        this.contents = contents;
+    }
+
+    public LocalDateTime getCreateDateTime() {
+        return createDateTime;
+    }
+
+    public void setCreateDateTime(LocalDateTime createDateTime) {
+        this.createDateTime = createDateTime;
+    }
+
+    public LocalDateTime getUpdateDateTime() {
+        return updateDateTime;
+    }
+
+    public void setUpdateDateTime(LocalDateTime updateDateTime) {
+        this.updateDateTime = updateDateTime;
+    }
+
+    public UserDTO getWriter() {
+        return writer;
+    }
+
+    public void setWriter(UserDTO writer) {
+        this.writer = writer;
+    }
+
+    public int getAnswerCount() {
+        return answerCount;
+    }
+
+    public void setAnswerCount(int answerCount) {
+        this.answerCount = answerCount;
+    }
+}

--- a/src/main/java/com/codessquad/qna/question/QuestionDTO.java
+++ b/src/main/java/com/codessquad/qna/question/QuestionDTO.java
@@ -1,23 +1,16 @@
 package com.codessquad.qna.question;
 
 import com.codessquad.qna.answer.AnswerDTO;
-import com.codessquad.qna.common.Constant;
+import com.codessquad.qna.common.BaseDTO;
 import com.codessquad.qna.user.UserDTO;
-import com.fasterxml.jackson.annotation.JsonFormat;
 
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class QuestionDTO {
-    private Long id;
+public class QuestionDTO extends BaseDTO {
     private String title;
     private String contents;
-
-    @JsonFormat(pattern = Constant.DEFAULT_DATE_TIME_FORMAT)
-    private LocalDateTime createDateTime;
-
-    private LocalDateTime updateDateTime;
     private UserDTO writer;
     private List<AnswerDTO> answers;
     private int answersCount;
@@ -26,11 +19,10 @@ public class QuestionDTO {
     }
 
     public QuestionDTO(Long id, String title, String contents, LocalDateTime createDateTime, LocalDateTime updateDateTime, UserDTO writer, List<AnswerDTO> answers, int answersCount) {
-        this.id = id;
+        super(id, createDateTime, updateDateTime);
+
         this.title = title;
         this.contents = contents;
-        this.createDateTime = createDateTime;
-        this.updateDateTime = updateDateTime;
         this.writer = writer;
         this.answers = answers;
         this.answersCount = answersCount;
@@ -80,11 +72,11 @@ public class QuestionDTO {
 
     public Question toEntity() {
         Question.Builder questionBuilder = Question.builder()
-                .setId(id)
+                .setId(getId())
                 .setTitle(title)
                 .setContents(contents)
-                .setCreateDateTime(createDateTime)
-                .setUpdateDateTime(updateDateTime)
+                .setCreateDateTime(getCreateDateTime())
+                .setUpdateDateTime(getUpdateDateTime())
                 .setWriter(writer.toEntity());
 
         if (answers != null) {
@@ -150,14 +142,6 @@ public class QuestionDTO {
         }
     }
 
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
-
     public String getTitle() {
         return title;
     }
@@ -172,22 +156,6 @@ public class QuestionDTO {
 
     public void setContents(String contents) {
         this.contents = contents;
-    }
-
-    public LocalDateTime getCreateDateTime() {
-        return createDateTime;
-    }
-
-    public void setCreateDateTime(LocalDateTime createDateTime) {
-        this.createDateTime = createDateTime;
-    }
-
-    public LocalDateTime getUpdateDateTime() {
-        return updateDateTime;
-    }
-
-    public void setUpdateDateTime(LocalDateTime updateDateTime) {
-        this.updateDateTime = updateDateTime;
     }
 
     public UserDTO getWriter() {

--- a/src/main/java/com/codessquad/qna/question/QuestionDTO.java
+++ b/src/main/java/com/codessquad/qna/question/QuestionDTO.java
@@ -49,6 +49,18 @@ public class QuestionDTO {
                 .build();
     }
 
+    public static QuestionDTO of(Question question, int answersCount) {
+        return builder()
+                .setId(question.getId())
+                .setTitle(question.getTitle())
+                .setContents(question.getContents())
+                .setCreateDateTime(question.getCreateDateTime())
+                .setUpdateDateTime(question.getUpdateDateTime())
+                .setWriter(UserDTO.from(question.getWriter()))
+                .setAnswersCount(answersCount)
+                .build();
+    }
+
     public static Builder builder() {
         return new Builder();
     }

--- a/src/main/java/com/codessquad/qna/question/QuestionDTO.java
+++ b/src/main/java/com/codessquad/qna/question/QuestionDTO.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class QuestionDTO {
     private Long id;
@@ -50,6 +51,22 @@ public class QuestionDTO {
 
     public static Builder builder() {
         return new Builder();
+    }
+
+    public Question toEntity() {
+        Question.Builder questionBuilder = Question.builder()
+                .setId(id)
+                .setTitle(title)
+                .setContents(contents)
+                .setCreateDateTime(createDateTime)
+                .setUpdateDateTime(updateDateTime)
+                .setWriter(writer.toEntity());
+
+        if (answers != null) {
+            questionBuilder.setAnswers(answers.stream().map(AnswerDTO::toEntity).collect(Collectors.toList()));
+        }
+
+        return questionBuilder.build();
     }
 
 

--- a/src/main/java/com/codessquad/qna/question/QuestionRepository.java
+++ b/src/main/java/com/codessquad/qna/question/QuestionRepository.java
@@ -6,4 +6,5 @@ import java.util.List;
 
 public interface QuestionRepository extends CrudRepository<Question, Long> {
     List<Question> findAll();
+    List<Question> findAllByDeletedFalse();
 }

--- a/src/main/java/com/codessquad/qna/question/QuestionService.java
+++ b/src/main/java/com/codessquad/qna/question/QuestionService.java
@@ -1,6 +1,8 @@
 package com.codessquad.qna.question;
 
+import com.codessquad.qna.answer.Answer;
 import com.codessquad.qna.answer.AnswerService;
+import com.codessquad.qna.exception.InsufficientAuthenticationException;
 import com.codessquad.qna.user.UserDTO;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -58,6 +60,14 @@ public class QuestionService {
     @Transactional
     public void delete(Long id, UserDTO currentSessionUser) {
         Question question = readVerifiedQuestion(id, currentSessionUser);
+        List<Answer> answer = question.getAnswers();
+
+        boolean differentWriterExists = answer.stream()
+                .anyMatch(question::isWriterDifferentFrom);
+
+        if (differentWriterExists) {
+            throw new InsufficientAuthenticationException("다른 작성자가 작성한 답변이 있으면 삭제할 수 없습니다.");
+        }
 
         answerService.deleteAll(question.getAnswers());
         question.delete();

--- a/src/main/java/com/codessquad/qna/question/QuestionService.java
+++ b/src/main/java/com/codessquad/qna/question/QuestionService.java
@@ -20,15 +20,11 @@ public class QuestionService {
     }
 
     public List<QuestionDTO> readAll() {
-        List<QuestionDTO> result = questionRepository.findAllByDeletedFalse().stream()
-                .map(QuestionDTO::from)
+        List<Question> questions = questionRepository.findAllByDeletedFalse();
+
+        return questions.stream()
+                .map(question -> QuestionDTO.of(question, answerService.countBy(question)))
                 .collect(Collectors.toList());
-
-        for (QuestionDTO question : result) {
-            question.setAnswers(answerService.readAll(question.getId()));
-        }
-
-        return result;
     }
 
     private Question readExistedQuestion(Long id) {

--- a/src/main/java/com/codessquad/qna/question/QuestionService.java
+++ b/src/main/java/com/codessquad/qna/question/QuestionService.java
@@ -33,11 +33,7 @@ public class QuestionService {
     }
 
     public QuestionDTO read(Long id) {
-        QuestionDTO result = QuestionDTO.from(readExistedQuestion(id));
-
-        result.setAnswers(answerService.readAll(id));
-
-        return result;
+        return QuestionDTO.of(readExistedQuestion(id), answerService.readAll(id));
     }
 
     public QuestionDTO readVerifiedQuestion(Long id, UserDTO user) {

--- a/src/main/java/com/codessquad/qna/question/QuestionService.java
+++ b/src/main/java/com/codessquad/qna/question/QuestionService.java
@@ -18,7 +18,7 @@ public class QuestionService {
     }
 
     public List<Question> readAll() {
-        List<Question> result = questionRepository.findAll();
+        List<Question> result = questionRepository.findAllByDeletedFalse();
 
         for (Question question : result) {
             question.setAnswers(answerService.readAll(question.getId()));
@@ -60,6 +60,7 @@ public class QuestionService {
         Question question = readVerifiedQuestion(id, currentSessionUser);
 
         answerService.deleteAll(question.getAnswers());
-        questionRepository.delete(question);
+        question.delete();
+        questionRepository.save(question);
     }
 }

--- a/src/main/java/com/codessquad/qna/question/QuestionService.java
+++ b/src/main/java/com/codessquad/qna/question/QuestionService.java
@@ -42,30 +42,30 @@ public class QuestionService {
         return result;
     }
 
-    public Question readVerifiedQuestion(Long id, UserDTO user) {
+    public QuestionDTO readVerifiedQuestion(Long id, UserDTO user) {
         Question result = questionRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("질문이 존재하지 않습니다. id : " + id));
 
         result.verifyWriter(user.toEntity());
 
-        return result;
+        return QuestionDTO.from(result);
     }
 
-    public void create(Question question) {
-        questionRepository.save(question);
+    public void create(QuestionDTO question) {
+        questionRepository.save(question.toEntity());
     }
 
-    public void update(Long id, Question newQuestion) {
+    public void update(Long id, QuestionDTO newQuestion) {
         Question existedQuestion = questionRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("질문이 존재하지 않습니다. id : " + id));
 
-        existedQuestion.update(newQuestion);
+        existedQuestion.update(newQuestion.toEntity());
         questionRepository.save(existedQuestion);
     }
 
     @Transactional
     public void delete(Long id, UserDTO currentSessionUser) {
-        Question question = readVerifiedQuestion(id, currentSessionUser);
+        Question question = readVerifiedQuestion(id, currentSessionUser).toEntity();
         List<Answer> answer = question.getAnswers();
 
         boolean differentWriterExists = answer.stream()

--- a/src/main/java/com/codessquad/qna/question/QuestionService.java
+++ b/src/main/java/com/codessquad/qna/question/QuestionService.java
@@ -18,12 +18,22 @@ public class QuestionService {
     }
 
     public List<Question> readAll() {
-        return questionRepository.findAll();
+        List<Question> result = questionRepository.findAll();
+
+        for (Question question : result) {
+            question.setAnswers(answerService.readAll(question.getId()));
+        }
+
+        return result;
     }
 
     public Question read(Long id) {
-        return questionRepository.findById(id)
+        Question result = questionRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("질문이 존재하지 않습니다. id : " + id));
+
+        result.setAnswers(answerService.readAll(id));
+
+        return result;
     }
 
     public Question readVerifiedQuestion(Long id, UserDTO user) {
@@ -49,7 +59,7 @@ public class QuestionService {
     public void delete(Long id, UserDTO currentSessionUser) {
         Question question = readVerifiedQuestion(id, currentSessionUser);
 
-        answerService.delete(question.getAnswers());
+        answerService.deleteAll(question.getAnswers());
         questionRepository.delete(question);
     }
 }

--- a/src/main/java/com/codessquad/qna/user/User.java
+++ b/src/main/java/com/codessquad/qna/user/User.java
@@ -5,6 +5,7 @@ import com.codessquad.qna.exception.InsufficientAuthenticationException;
 import javax.persistence.*;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 @Entity
 public class User {
@@ -123,6 +124,19 @@ public class User {
         } catch (IllegalArgumentException e) {
             throw new InsufficientAuthenticationException("권한이 없는 사용자입니다.", e);
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        User user = (User) o;
+        return Objects.equals(id, user.id) && Objects.equals(userId, user.userId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, userId);
     }
 
     @Override

--- a/src/main/java/com/codessquad/qna/user/User.java
+++ b/src/main/java/com/codessquad/qna/user/User.java
@@ -1,10 +1,9 @@
 package com.codessquad.qna.user;
 
 import com.codessquad.qna.exception.InsufficientAuthenticationException;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import javax.persistence.*;
-import java.util.Arrays;
-import java.util.List;
 import java.util.Objects;
 
 @Entity
@@ -17,6 +16,7 @@ public class User {
     private String userId;
 
     @Column(nullable = false, length = 20)
+    @JsonIgnore
     private String password;
 
     @Column(nullable = false, length = 20)

--- a/src/main/java/com/codessquad/qna/user/User.java
+++ b/src/main/java/com/codessquad/qna/user/User.java
@@ -1,17 +1,14 @@
 package com.codessquad.qna.user;
 
+import com.codessquad.qna.common.BaseEntity;
 import com.codessquad.qna.exception.InsufficientAuthenticationException;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 
-import javax.persistence.*;
+import javax.persistence.Column;
+import javax.persistence.Entity;
 import java.util.Objects;
 
 @Entity
-public class User {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-
+public class User extends BaseEntity {
     @Column(nullable = false, length = 20, unique = true)
     private String userId;
 
@@ -28,7 +25,8 @@ public class User {
     }
 
     public User(Long id, String userId, String password, String name, String email) {
-        this.id = id;
+        super(id);
+
         this.userId = userId;
         this.password = password;
         this.name = name;
@@ -76,10 +74,6 @@ public class User {
         }
     }
 
-    public Long getId() {
-        return id;
-    }
-
     public String getUserId() {
         return userId;
     }
@@ -111,7 +105,7 @@ public class User {
     }
 
     private void checkId(Long id) {
-        if (!this.id.equals(id)) {
+        if (!getId().equals(id)) {
             throw new IllegalArgumentException("잘못된 ID입니다. id : " + id);
         }
     }
@@ -130,12 +124,12 @@ public class User {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         User user = (User) o;
-        return Objects.equals(id, user.id) && Objects.equals(userId, user.userId);
+        return Objects.equals(getId(), user.getId()) && Objects.equals(userId, user.userId);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, userId);
+        return Objects.hash(getId(), userId);
     }
 
     @Override

--- a/src/main/java/com/codessquad/qna/user/User.java
+++ b/src/main/java/com/codessquad/qna/user/User.java
@@ -16,7 +16,6 @@ public class User {
     private String userId;
 
     @Column(nullable = false, length = 20)
-    @JsonIgnore
     private String password;
 
     @Column(nullable = false, length = 20)

--- a/src/main/java/com/codessquad/qna/user/UserDTO.java
+++ b/src/main/java/com/codessquad/qna/user/UserDTO.java
@@ -22,6 +22,10 @@ public class UserDTO {
     }
 
     public static UserDTO from(User user) {
+        if (user == null) {
+            return new UserDTO();
+        }
+
         return new UserDTO(
                 user.getId(),
                 user.getUserId(), user.getPassword(),

--- a/src/main/java/com/codessquad/qna/user/UserDTO.java
+++ b/src/main/java/com/codessquad/qna/user/UserDTO.java
@@ -1,12 +1,18 @@
 package com.codessquad.qna.user;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.springframework.util.StringUtils;
 
 public class UserDTO {
     private Long id;
     private String userId;
+
+    @JsonIgnore
     private String password;
+
+    @JsonIgnore
     private String newPassword;
+    
     private String name;
     private String email;
 

--- a/src/main/java/com/codessquad/qna/user/UserDTO.java
+++ b/src/main/java/com/codessquad/qna/user/UserDTO.java
@@ -1,10 +1,10 @@
 package com.codessquad.qna.user;
 
+import com.codessquad.qna.common.BaseDTO;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.springframework.util.StringUtils;
 
-public class UserDTO {
-    private Long id;
+public class UserDTO extends BaseDTO {
     private String userId;
 
     @JsonIgnore
@@ -12,7 +12,7 @@ public class UserDTO {
 
     @JsonIgnore
     private String newPassword;
-    
+
     private String name;
     private String email;
 
@@ -20,7 +20,8 @@ public class UserDTO {
     }
 
     public UserDTO(Long id, String userId, String password, String name, String email) {
-        this.id = id;
+        super(id);
+
         this.userId = userId;
         this.password = password;
         this.name = name;
@@ -38,14 +39,6 @@ public class UserDTO {
                 user.getName(),
                 user.getEmail()
         );
-    }
-
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
     }
 
     public String getUserId() {
@@ -94,7 +87,7 @@ public class UserDTO {
 
     public User toEntity() {
         return User.builder()
-                .setId(id)
+                .setId(getId())
                 .setUserId(userId)
                 .setPassword(password)
                 .setName(name)
@@ -105,7 +98,7 @@ public class UserDTO {
     @Override
     public String toString() {
         return "UserDTO{" +
-                "id=" + id +
+                "id=" + getId() +
                 ", userId='" + userId + '\'' +
                 ", password='" + password + '\'' +
                 ", newPassword='" + newPassword + '\'' +

--- a/src/main/java/com/codessquad/qna/user/UserService.java
+++ b/src/main/java/com/codessquad/qna/user/UserService.java
@@ -24,22 +24,24 @@ public class UserService {
                 .collect(Collectors.toList());
     }
 
-    public UserDTO read(Long id) {
-        User result = userRepository.findById(id)
+    private User readExistedUser(Long id) {
+        return userRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("존재하지 않는 사용자 입니다. id : " + id));
-
-        return UserDTO.from(result);
     }
 
-    private UserDTO read(String userId) {
-        User result = userRepository.findByUserId(userId)
+    private User readExistedUser(String userId) {
+        return userRepository.findByUserId(userId)
                 .orElseThrow(() -> new ResourceNotFoundException("존재하지 않는 사용자 입니다. id : " + userId));
+    }
+
+    public UserDTO read(Long id) {
+        User result = readExistedUser(id);
 
         return UserDTO.from(result);
     }
 
     public UserDTO readVerifiedUser(Long id, UserDTO verificationTarget) {
-        User result = read(id).toEntity();
+        User result = readExistedUser(id);
         result.verifyWith(verificationTarget.toEntity());
 
         return UserDTO.from(result);
@@ -47,7 +49,7 @@ public class UserService {
 
     public UserDTO readPasswordVerifiedUser(String userId, String password) {
         try {
-            User user = read(userId).toEntity();
+            User user = readExistedUser(userId);
             user.checkPassword(password);
 
             return UserDTO.from(user);

--- a/src/main/resources/static/js/scripts.js
+++ b/src/main/resources/static/js/scripts.js
@@ -39,12 +39,13 @@ function onSuccess(data, status) {
             data.writer.userId,
             data.createDateTime,
             data.comment,
-            data.question.id,
+            data.questionId,
             data.id
         );
 
     $(".answer-write").before(answer);
     $(".answer-write textarea").val("");
+    $(".qna-comment-count").children().text(data.answersCount)
 }
 
 $(".qna-comment-slipp-articles").click(deleteAnswer);
@@ -64,7 +65,7 @@ function deleteAnswer(e) {
             },
             success: function (data, status) {
                 $(e.target).closest("article").remove();
-                $(".qna-comment-count").children().text(data.question.answerCount)
+                $(".qna-comment-count").children().text(data.answersCount)
             }
         })
     }

--- a/src/main/resources/static/js/scripts.js
+++ b/src/main/resources/static/js/scripts.js
@@ -1,9 +1,48 @@
-String.prototype.format = function() {
-  var args = arguments;
-  return this.replace(/{(\d+)}/g, function(match, number) {
-    return typeof args[number] != 'undefined'
-        ? args[number]
-        : match
-        ;
-  });
+String.prototype.format = function () {
+    var args = arguments;
+    return this.replace(/{(\d+)}/g, function (match, number) {
+        return typeof args[number] != 'undefined'
+            ? args[number]
+            : match
+            ;
+    });
 };
+
+$(".answer-write button[type=submit]").click(addAnswer);
+
+function addAnswer(e) {
+    e.preventDefault();
+
+    const answerWrite = $(".answer-write");
+    const queryString = answerWrite.serialize();
+    const url = answerWrite.attr("action");
+
+    $.ajax({
+        type: 'post',
+        url: url,
+        data: queryString,
+        dataType: 'json',
+        error: onError,
+        success: onSuccess
+    })
+}
+
+function onError() {
+    console.error("error occurred")
+}
+
+function onSuccess(data, status) {
+    console.log(data);
+
+    const answer = $("#answerTemplate").html()
+        .format(
+            data.writer.userId,
+            data.createDateTime,
+            data.comment,
+            data.question.id,
+            data.id
+        );
+
+    $(".answer-write").before(answer);
+    $(".answer-write textarea").val("");
+}

--- a/src/main/resources/static/js/scripts.js
+++ b/src/main/resources/static/js/scripts.js
@@ -46,3 +46,26 @@ function onSuccess(data, status) {
     $(".answer-write").before(answer);
     $(".answer-write textarea").val("");
 }
+
+$(".qna-comment-slipp-articles").click(deleteAnswer);
+
+function deleteAnswer(e) {
+    if (e.target.className == "link-delete-article") {
+        e.preventDefault();
+
+        const url = $(e.target).attr("href");
+
+        $.ajax({
+            type: 'delete',
+            url: url,
+            dataType: 'json',
+            error: function (xhr, status) {
+                console.error("error")
+            },
+            success: function (data, status) {
+                $(e.target).closest("article").remove();
+                $(".qna-comment-count").children().text(data.question.answerCount)
+            }
+        })
+    }
+}

--- a/src/main/resources/templates/error/400.html
+++ b/src/main/resources/templates/error/400.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="kr">
+{{#partial "content"}}
+<div class="container" id="main">
+    <div class="col-md-6 col-md-offset-3">
+        <div class="panel panel-default content-main">
+            <div class="alert alert-danger" role="alert">잘못된 요청입니다.</div>
+        </div>
+    </div>
+</div>
+{{/partial}}
+{{> base/layout}}
+</html>

--- a/src/main/resources/templates/qna/answerUpdateForm.html
+++ b/src/main/resources/templates/qna/answerUpdateForm.html
@@ -12,7 +12,7 @@
                     <div class="qna-comment-slipp">
                         <div class="qna-comment-slipp-articles">
                             <form class="submit-write" name="answer"
-                                  action="/questions/{{answer.question.id}}/answers/{{answer.id}}"
+                                  action="/questions/{{answer.questionId}}/answers/{{answer.id}}"
                                   method="post">
                                 <input type="hidden" name="_method" value="PUT"/>
                                 <div class="form-group" style="padding:14px;">

--- a/src/main/resources/templates/qna/list.html
+++ b/src/main/resources/templates/qna/list.html
@@ -19,7 +19,7 @@
                             </div>
                             <div class="reply" title="댓글">
                                 <i class="icon-reply"></i>
-                                <span class="point">{{answers.length}}</span>
+                                <span class="point">{{answersCount}}</span>
                             </div>
                         </div>
                     </div>

--- a/src/main/resources/templates/qna/list.html
+++ b/src/main/resources/templates/qna/list.html
@@ -14,7 +14,7 @@
                             </strong>
                             <div class="auth-info">
                                 <i class="icon-add-comment"></i>
-                                <span class="time">{{formatDateTime createDateTime}}</span>
+                                <span class="time">{{formattedDateTime}}</span>
                                 <a href="/users/{{writer.id}}" class="author">{{writer.name}}</a>
                             </div>
                             <div class="reply" title="댓글">

--- a/src/main/resources/templates/qna/show.html
+++ b/src/main/resources/templates/qna/show.html
@@ -16,7 +16,7 @@
                       <div class="article-header-text">
                           <a href="/users/{{question.writer.id}}" class="article-author-name">{{question.writer.name}}</a>
                           <a href="/questions/{{question.id}}" class="article-header-time" title="퍼머링크">
-                              {{formatDateTime question.createDateTime}}
+                              {{question.formattedDateTime}}
                               <i class="icon-link"></i>
                           </a>
                       </div>
@@ -57,7 +57,7 @@
                                   <div class="article-header-text">
                                       <a href="/users/{{writer.id}}" class="article-author-name">{{writer.name}}</a>
                                       <a href="#answer-{{id}}" class="article-header-time" title="퍼머링크">
-                                          {{formatDateTime createDateTime}}
+                                          {{formattedDateTime}}
                                       </a>
                                   </div>
                               </div>

--- a/src/main/resources/templates/qna/show.html
+++ b/src/main/resources/templates/qna/show.html
@@ -112,7 +112,7 @@
 		<div class="article-util">
 		<ul class="article-util-list">
 			<li>
-				<a class="link-modify-article" href="/api/questions/{3}/answers/{4}">수정</a>
+				<a class="link-modify-article" href="/questions/{3}/answers/{4}/form">수정</a>
 			</li>
 			<li>
                 <a class="link-delete-article" href="/api/questions/{3}/answers/{4}">삭제</a>

--- a/src/main/resources/templates/qna/show.html
+++ b/src/main/resources/templates/qna/show.html
@@ -71,10 +71,7 @@
                                           <a class="link-modify-article" href="/questions/{{question.id}}/answers/{{id}}/form">수정</a>
                                       </li>
                                       <li>
-                                          <form class="delete-answer-form" action="/questions/{{question.id}}/answers/{{id}}" method="POST">
-                                              <input type="hidden" name="_method" value="DELETE">
-                                              <button type="submit" class="delete-answer-button">삭제</button>
-                                          </form>
+                                          <a class="link-delete-article" href="/api/questions/{{question.id}}/answers/{{id}}">삭제</a>
                                       </li>
                                   </ul>
                                   {{/ifEquals}}
@@ -115,14 +112,11 @@
 		<div class="article-util">
 		<ul class="article-util-list">
 			<li>
-				<a class="link-modify-article" href="/api/qna/updateAnswer/{3}">수정</a>
+				<a class="link-modify-article" href="/api/questions/{3}/answers/{4}">수정</a>
 			</li>
 			<li>
-				<form class="delete-answer-form" action="/api/questions/{3}/answers/{4}" method="POST">
-					<input type="hidden" name="_method" value="DELETE">
-                     <button type="submit" class="delete-answer-button">삭제</button>
-				</form>
-			</li>
+                <a class="link-delete-article" href="/api/questions/{3}/answers/{4}">삭제</a>
+            </li>
 		</ul>
 		</div>
 	</article>

--- a/src/main/resources/templates/qna/show.html
+++ b/src/main/resources/templates/qna/show.html
@@ -21,7 +21,7 @@
                           </a>
                       </div>
                   </div>
-                  <div class="article-doc">
+                  <div class="article-doc" style="white-space:pre-wrap;">
                       <p>{{question.contents}}</p>
                   </div>
                   <div class="article-util">

--- a/src/main/resources/templates/qna/show.html
+++ b/src/main/resources/templates/qna/show.html
@@ -82,7 +82,7 @@
                           </article>
                           {{/each}}
                           {{#if sessionedUser}}
-                          <form class="submit-write" name="answer" action="/questions/{{question.id}}/answers" method="post">
+                          <form class="answer-write" name="answer" action="/api/questions/{{question.id}}/answers" method="post">
                               <div class="form-group" style="padding:14px;">
                                   <textarea class="form-control" placeholder="Update your status" name="comment"></textarea>
                               </div>


### PR DESCRIPTION
안녕하세요 프레디입니다.
미션3에서 선택 미션까지 완료하니, 미션4에서는 선택 미션 외에 추가되는 부분이 없는 것 같아 미션5까지 진행했습니다.
기능 자체의 구현보다는 json으로 반환해야 할 일이 생기면서 DTO를 추가로 정의해주고, 이로 인해 발생하는 오류와 중복을 제거하는데 시간을 많이 쏟았던 것 같습니다.

[배포 사이트](https://spring-boot-qna-freddie.herokuapp.com/)

**Soft delete 구현**

-   `Question`과 `Answer`를 `deleted` 컬럼으로 삭제합니다.

-   Soft delete로 구현하니 조회가 조금 까다로워졌습니다. query creation으로는 join on 설정을 해주기가 까다로웠습니다. `Question`안의 `answers`를 조회할 때 `deleted`된 것만 찾아와야 하기 때문입니다. 따라서 콜렉션의 기본 fetch가 lazy인 점에서 착안하여, 객체 그래프에 접근하기 전에 새롭게 `answer`를 조회하여 넣어주는 식으로 했습니다. jpa criteria 어노테이션을 사용하여 해결할 수도 있다는 것을 들었는데, 프록시를 이용한 lazy로딩과 객체 조회 시점을 이해하는데 의의를 뒀습니다.

**질문 답변 수 기능 개선**

-   기존에는 `Question`에서 함께 조회되는 `answers`를 이용하여 개수를 세어줬습니다. handlebars에서 `{{answers.length}}` 와 같이 리스트의 길이를 출력해줄 수 있었기 때문입니다.

-   그런데 성능상의 이슈가 발생할 수 있고, 이를 위해 `Question`테이블에서 직접 답변 수를 관리하는 방법을 제시해주셨는데, 저는 좋지 않은 방법이라 생각하여 count를 따로 해줬습니다.

    -   직접 답변 수를 관리하면 정확한 개수가 관리되지 않을 것입니다.

        >   구현을 완료하고 생각해보니 개수를 민감하게 관리해야 하는게 아니면, 하루 한 번이나, 시간당 몇 회 이런 식으로 정해서 정확한 개수로 초기화해주는 작업을 할 수도 있을 것 같습니다.

    -   성능상의 문제는 제 컴퓨팅 환경의 한계때문에 1천만건 정도까지 밖에 테스트하지 못했지만, 이 정도 선 까지는 인덱스를 지정해줘서 해결할 수 있음을 확인했습니다. 만약 속도가 느려진다면 인덱스를 고려해볼 수 있다고 생각했습니다.

    -   그리고 만약 그 정도로 count의 속도가 나오지 않는 경우라면, 애초에 select자체가 느릴 것이기 때문에 근본적으로 다른방법을 강구해봐야하지 않나 하는 생각을 해봤습니다.

-   불필요한 `answers` 조회를 하지 않도록 하고, count를 세어줬습니다. 객체를 호출하지 않으면 해당 객체그래프(객체 노드라 하는게 더 맞는 표현인지 잘 모르겠습니다)에 접근을 하지 않아 조회 쿼리가 발생하지 않기 때문에, DTO에서 `answers`를 호출하지 않도록 하였습니다.

**AJAX로 답변 추가, 삭제 기능 구현**

-   삭제 기능은 이벤트 위임을 이용하여 기존의 버튼도 동작하게 해줬습니다.
-   json으로 답변을 하니 entity 클래스와 실제 데이터 간의 괴리가 발생해 DTO를 추가적으로 구현했습니다. 이로 인해 entity 클래스가 가지고 있던 setter 메소드를 정리할 수 있었습니다.  순환참조 때문에 애를 먹었는데 팩토리 메소드를 만들어 해결해줬지만 좋은 방법인지는 잘 모르겠습니다.

**공통 도메인 클래스 작성**

-   `BaseEntity`와 `BaseDTO`를 이용하여 중복을 제거해줬습니다.
-   `BaseDTO`가 있으면 날짜 포메팅을 위해 handlebars helper를 사용하지 않아도 깔끔하게 구현할 수 있어 해당 부분 제거해줬습니다.

감사합니다!