### PR TITLE
[아이작] 미션4: 객체-관계 매핑

### DIFF
--- a/src/main/java/com/codessquad/qna/controller/AnswerController.java
+++ b/src/main/java/com/codessquad/qna/controller/AnswerController.java
@@ -1,0 +1,34 @@
+package com.codessquad.qna.controller;
+
+import com.codessquad.qna.entity.User;
+import com.codessquad.qna.service.AnswerService;
+import com.codessquad.qna.util.HttpSessionUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import javax.servlet.http.HttpSession;
+
+@Controller
+@RequestMapping("/questions/{questionId}/answers")
+public class AnswerController {
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+    private final AnswerService answerService;
+
+    @Autowired
+    public AnswerController(AnswerService answerService) {
+        this.answerService = answerService;
+    }
+
+    @PostMapping
+    public String create(@PathVariable long questionId, String contents, HttpSession session) {
+        logger.debug("{}번 질문에 답변 생성 요청", questionId);
+        User user = HttpSessionUtil.getUser(session);
+        answerService.addAnswer(questionId, user, contents);
+        return "redirect:/questions/" + questionId;
+    }
+}

--- a/src/main/java/com/codessquad/qna/controller/AnswerController.java
+++ b/src/main/java/com/codessquad/qna/controller/AnswerController.java
@@ -2,7 +2,7 @@ package com.codessquad.qna.controller;
 
 import com.codessquad.qna.entity.User;
 import com.codessquad.qna.service.AnswerService;
-import com.codessquad.qna.util.HttpSessionUtil;
+import com.codessquad.qna.util.HttpSessionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,7 +28,7 @@ public class AnswerController {
     @PostMapping
     public String create(@PathVariable long questionId, String contents, HttpSession session) {
         logger.debug("{}번 질문에 답변 생성 요청", questionId);
-        User user = HttpSessionUtil.getUser(session);
+        User user = HttpSessionUtils.getUser(session);
         answerService.addAnswer(questionId, user, contents);
         return "redirect:/questions/" + questionId;
     }
@@ -36,7 +36,7 @@ public class AnswerController {
     @DeleteMapping("/{answerId}")
     public String delete(@PathVariable long questionId, @PathVariable long answerId, HttpSession session) {
         logger.debug("{}번 질문의 {}번 답변 삭제 요청", questionId, answerId);
-        User user = HttpSessionUtil.getUser(session);
+        User user = HttpSessionUtils.getUser(session);
         answerService.deleteAnswer(answerId, user);
         return "redirect:/questions/" + questionId;
     }

--- a/src/main/java/com/codessquad/qna/controller/AnswerController.java
+++ b/src/main/java/com/codessquad/qna/controller/AnswerController.java
@@ -7,6 +7,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -29,6 +30,14 @@ public class AnswerController {
         logger.debug("{}번 질문에 답변 생성 요청", questionId);
         User user = HttpSessionUtil.getUser(session);
         answerService.addAnswer(questionId, user, contents);
+        return "redirect:/questions/" + questionId;
+    }
+
+    @DeleteMapping("/{answerId}")
+    public String delete(@PathVariable long questionId, @PathVariable long answerId, HttpSession session) {
+        logger.debug("{}번 질문의 {}번 답변 삭제 요청", questionId, answerId);
+        User user = HttpSessionUtil.getUser(session);
+        answerService.deleteAnswer(answerId, user);
         return "redirect:/questions/" + questionId;
     }
 }

--- a/src/main/java/com/codessquad/qna/controller/QuestionController.java
+++ b/src/main/java/com/codessquad/qna/controller/QuestionController.java
@@ -5,7 +5,7 @@ import com.codessquad.qna.entity.User;
 import com.codessquad.qna.exception.NotAuthorizedException;
 import com.codessquad.qna.exception.UserNotFoundInSessionException;
 import com.codessquad.qna.service.QuestionService;
-import com.codessquad.qna.util.HttpSessionUtil;
+import com.codessquad.qna.util.HttpSessionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,28 +34,28 @@ public class QuestionController {
 
     @PostMapping
     public String create(String title, String contents, HttpSession session) {
-        User user = HttpSessionUtil.getUser(session);
+        User user = HttpSessionUtils.getUser(session);
         questionService.addQuestion(user, title, contents);
         return "redirect:/";
     }
 
     @PutMapping("/{id}")
     public String update(@PathVariable long id, String contents, String title, HttpSession session) {
-        User tryToUpdate = HttpSessionUtil.getUser(session);
+        User tryToUpdate = HttpSessionUtils.getUser(session);
         questionService.updateQuestion(id, title, contents, tryToUpdate);
         return "redirect:/questions/" + id;
     }
 
     @DeleteMapping("/{id}")
     public String delete(@PathVariable long id, HttpSession session) {
-        User tryToDelete = HttpSessionUtil.getUser(session);
+        User tryToDelete = HttpSessionUtils.getUser(session);
         questionService.deleteQuestion(id, tryToDelete);
         return "redirect:/";
     }
 
     @GetMapping("/form")
     public String form(HttpSession session) {
-        if (!HttpSessionUtil.hasUser(session)) {
+        if (!HttpSessionUtils.hasUser(session)) {
             throw new UserNotFoundInSessionException();
         }
         return "qna/form";
@@ -71,7 +71,7 @@ public class QuestionController {
     @GetMapping("/{id}/form")
     public String updateForm(@PathVariable int id, Model model, HttpSession session) {
         Question question = questionService.getQuestion(id);
-        if (!HttpSessionUtil.isAuthorized(question.getWriter().getId(), session)) {
+        if (!HttpSessionUtils.isAuthorized(question.getWriter().getId(), session)) {
             throw new NotAuthorizedException();
         }
         model.addAttribute("question", question);

--- a/src/main/java/com/codessquad/qna/controller/QuestionController.java
+++ b/src/main/java/com/codessquad/qna/controller/QuestionController.java
@@ -34,8 +34,7 @@ public class QuestionController {
     @PostMapping
     public String create(String title, String contents, HttpSession session) {
         User user = HttpSessionUtil.getUser(session);
-        Question toCreate = new Question(user, title, contents);
-        questionService.addQuestion(toCreate);
+        questionService.addQuestion(user, title, contents);
         return "redirect:/";
     }
 

--- a/src/main/java/com/codessquad/qna/controller/QuestionController.java
+++ b/src/main/java/com/codessquad/qna/controller/QuestionController.java
@@ -40,22 +40,16 @@ public class QuestionController {
 
     @PutMapping("/{id}")
     public String update(@PathVariable long id, String contents, String title, HttpSession session) {
-        Question question = questionService.getQuestion(id);
-        if (HttpSessionUtil.isAuthorized(question.getWriter().getId(), session)) {
-            questionService.updateQuestion(id, title, contents);
-            return "redirect:/questions/" + id;
-        }
-        throw new IllegalStateException("자신의 글만 수정할 수 있습니다.");
+        User tryToUpdate = HttpSessionUtil.getUser(session);
+        questionService.updateQuestion(id, title, contents, tryToUpdate);
+        return "redirect:/questions/" + id;
     }
 
     @DeleteMapping("/{id}")
     public String delete(@PathVariable long id, HttpSession session) {
-        Question question = questionService.getQuestion(id);
-        if (HttpSessionUtil.isAuthorized(question.getWriter().getId(), session)) {
-            questionService.deleteQuestion(id);
-            return "redirect:/";
-        }
-        throw new IllegalStateException("자신의 글만 삭제할 수 있습니다.");
+        User tryToDelete = HttpSessionUtil.getUser(session);
+        questionService.deleteQuestion(id, tryToDelete);
+        return "redirect:/";
     }
 
     @GetMapping("/form")
@@ -75,9 +69,8 @@ public class QuestionController {
 
     @GetMapping("/{id}/form")
     public String updateForm(@PathVariable int id, Model model, HttpSession session) {
-        User user = HttpSessionUtil.getUser(session);
         Question question = questionService.getQuestion(id);
-        if (!question.getWriter().verify(user)) {
+        if (HttpSessionUtil.isAuthorized(question.getWriter().getId(), session)) {
             throw new IllegalStateException("자신의 글만 수정할 수 있습니다.");
         }
         model.addAttribute("question", question);

--- a/src/main/java/com/codessquad/qna/controller/QuestionController.java
+++ b/src/main/java/com/codessquad/qna/controller/QuestionController.java
@@ -2,6 +2,7 @@ package com.codessquad.qna.controller;
 
 import com.codessquad.qna.entity.Question;
 import com.codessquad.qna.entity.User;
+import com.codessquad.qna.exception.NotAuthorizedException;
 import com.codessquad.qna.exception.UserNotFoundInSessionException;
 import com.codessquad.qna.service.QuestionService;
 import com.codessquad.qna.util.HttpSessionUtil;
@@ -70,8 +71,8 @@ public class QuestionController {
     @GetMapping("/{id}/form")
     public String updateForm(@PathVariable int id, Model model, HttpSession session) {
         Question question = questionService.getQuestion(id);
-        if (HttpSessionUtil.isAuthorized(question.getWriter().getId(), session)) {
-            throw new IllegalStateException("자신의 글만 수정할 수 있습니다.");
+        if (!HttpSessionUtil.isAuthorized(question.getWriter().getId(), session)) {
+            throw new NotAuthorizedException();
         }
         model.addAttribute("question", question);
         return "/qna/updateForm";

--- a/src/main/java/com/codessquad/qna/controller/UserController.java
+++ b/src/main/java/com/codessquad/qna/controller/UserController.java
@@ -2,7 +2,7 @@ package com.codessquad.qna.controller;
 
 import com.codessquad.qna.entity.User;
 import com.codessquad.qna.exception.NotAuthorizedException;
-import com.codessquad.qna.exception.UserNotFoundException;
+import com.codessquad.qna.exception.NotFoundException;
 import com.codessquad.qna.service.UserService;
 import com.codessquad.qna.util.HttpSessionUtils;
 import org.slf4j.Logger;
@@ -84,7 +84,7 @@ public class UserController {
                 return "redirect:/";
             }
             return "redirect:/users/login/failed";
-        } catch (UserNotFoundException ex) {
+        } catch (NotFoundException ex) {
             return "redirect:/users/login/failed";
         }
     }

--- a/src/main/java/com/codessquad/qna/controller/UserController.java
+++ b/src/main/java/com/codessquad/qna/controller/UserController.java
@@ -4,7 +4,7 @@ import com.codessquad.qna.entity.User;
 import com.codessquad.qna.exception.NotAuthorizedException;
 import com.codessquad.qna.exception.UserNotFoundException;
 import com.codessquad.qna.service.UserService;
-import com.codessquad.qna.util.HttpSessionUtil;
+import com.codessquad.qna.util.HttpSessionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -46,8 +46,8 @@ public class UserController {
 
     @GetMapping("/{id}/form")
     public String updateForm(@PathVariable long id, Model model, HttpSession session) {
-        if (HttpSessionUtil.isAuthorized(id, session)) {
-            User user = HttpSessionUtil.getUser(session);
+        if (HttpSessionUtils.isAuthorized(id, session)) {
+            User user = HttpSessionUtils.getUser(session);
             model.addAttribute("user", user);
             return "user/updateForm";
         }
@@ -56,7 +56,7 @@ public class UserController {
 
     @PutMapping("/{id}/update")
     public String update(@PathVariable long id, User user, HttpSession session) {
-        if (HttpSessionUtil.isAuthorized(id, session)) {
+        if (HttpSessionUtils.isAuthorized(id, session)) {
             userService.updateUser(user);
             return "redirect:/users";
         }
@@ -80,7 +80,7 @@ public class UserController {
         try {
             User toLogin = userService.getUser(user.getUserId());
             if (toLogin.verify(user)) {
-                session.setAttribute(HttpSessionUtil.USER_KEY, toLogin);
+                session.setAttribute(HttpSessionUtils.USER_KEY, toLogin);
                 return "redirect:/";
             }
             return "redirect:/users/login/failed";
@@ -92,7 +92,7 @@ public class UserController {
     @GetMapping("/logout")
     public String logout(HttpSession session) {
         logger.debug("logout 요청");
-        session.removeAttribute(HttpSessionUtil.USER_KEY);
+        session.removeAttribute(HttpSessionUtils.USER_KEY);
         return "redirect:/";
     }
 }

--- a/src/main/java/com/codessquad/qna/controller/UserController.java
+++ b/src/main/java/com/codessquad/qna/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.codessquad.qna.controller;
 
 import com.codessquad.qna.entity.User;
+import com.codessquad.qna.exception.NotAuthorizedException;
 import com.codessquad.qna.exception.UserNotFoundException;
 import com.codessquad.qna.service.UserService;
 import com.codessquad.qna.util.HttpSessionUtil;
@@ -50,7 +51,7 @@ public class UserController {
             model.addAttribute("user", user);
             return "user/updateForm";
         }
-        throw new IllegalStateException("자신의 정보만 수정할 수 있습니다.");
+        throw new NotAuthorizedException();
     }
 
     @PutMapping("/{id}/update")
@@ -59,7 +60,7 @@ public class UserController {
             userService.updateUser(user);
             return "redirect:/users";
         }
-        throw new IllegalStateException("자신의 정보만 수정할 수 있습니다.");
+        throw new NotAuthorizedException();
     }
 
     @GetMapping("/login")

--- a/src/main/java/com/codessquad/qna/entity/Answer.java
+++ b/src/main/java/com/codessquad/qna/entity/Answer.java
@@ -1,0 +1,36 @@
+package com.codessquad.qna.entity;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "ANSWER")
+public class Answer {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    @ManyToOne
+    @JoinColumn(foreignKey = @ForeignKey(name = "fk_answer_question"))
+    private Question question;
+
+    @ManyToOne
+    @JoinColumn(foreignKey = @ForeignKey(name = "fk_answer_writer"))
+    private User writer;
+
+    @Column(nullable = false, length = 3000)
+    private String contents;
+
+    @Column(nullable = false)
+    private LocalDateTime writeDateTime;
+
+    protected Answer() {
+    }
+
+    public Answer(Question question, User writer, String contents) {
+        this.question = question;
+        this.writer = writer;
+        this.contents = contents;
+        this.writeDateTime = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/codessquad/qna/entity/Answer.java
+++ b/src/main/java/com/codessquad/qna/entity/Answer.java
@@ -9,7 +9,7 @@ import java.time.format.DateTimeFormatter;
 public class Answer {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private long id;
+    private Long id;
 
     @ManyToOne
     @JoinColumn(foreignKey = @ForeignKey(name = "fk_answer_question"))

--- a/src/main/java/com/codessquad/qna/entity/Answer.java
+++ b/src/main/java/com/codessquad/qna/entity/Answer.java
@@ -25,6 +25,9 @@ public class Answer {
     @Column(nullable = false)
     private LocalDateTime writeDateTime;
 
+    @Column(nullable = false, columnDefinition = "boolean default false")
+    private boolean deleted;
+
     protected Answer() {
     }
 
@@ -57,6 +60,14 @@ public class Answer {
 
     public String getFormattedWriteDateTime() {
         return writeDateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
+    }
+
+    public boolean isDeleted() {
+        return this.deleted;
+    }
+
+    public void delete() {
+        this.deleted = true;
     }
 
     public boolean isWriter(User user) {

--- a/src/main/java/com/codessquad/qna/entity/Answer.java
+++ b/src/main/java/com/codessquad/qna/entity/Answer.java
@@ -58,4 +58,8 @@ public class Answer {
     public String getFormattedWriteDateTime() {
         return writeDateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
     }
+
+    public boolean isWriter(User user) {
+        return writer.isSameId(user);
+    }
 }

--- a/src/main/java/com/codessquad/qna/entity/Answer.java
+++ b/src/main/java/com/codessquad/qna/entity/Answer.java
@@ -34,3 +34,4 @@ public class Answer {
         this.writeDateTime = LocalDateTime.now();
     }
 }
+ 

--- a/src/main/java/com/codessquad/qna/entity/Answer.java
+++ b/src/main/java/com/codessquad/qna/entity/Answer.java
@@ -2,6 +2,7 @@ package com.codessquad.qna.entity;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 @Entity
 @Table(name = "ANSWER")
@@ -33,5 +34,28 @@ public class Answer {
         this.contents = contents;
         this.writeDateTime = LocalDateTime.now();
     }
+
+    public long getId() {
+        return id;
+    }
+
+    public Question getQuestion() {
+        return question;
+    }
+
+    public User getWriter() {
+        return writer;
+    }
+
+    public String getContents() {
+        return contents;
+    }
+
+    public LocalDateTime getWriteDateTime() {
+        return writeDateTime;
+    }
+
+    public String getFormattedWriteDateTime() {
+        return writeDateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
+    }
 }
- 

--- a/src/main/java/com/codessquad/qna/entity/Question.java
+++ b/src/main/java/com/codessquad/qna/entity/Question.java
@@ -62,4 +62,8 @@ public class Question {
         this.title = title;
         this.contents = contents;
     }
+
+    public boolean isWriter(User user) {
+        return writer.isSameId(user);
+    }
 }

--- a/src/main/java/com/codessquad/qna/entity/Question.java
+++ b/src/main/java/com/codessquad/qna/entity/Question.java
@@ -77,7 +77,7 @@ public class Question {
     }
 
     public void delete() {
-        answers.stream().forEach(x -> x.delete());
+        answers.stream().forEach(answer -> answer.delete());
         this.deleted = true;
     }
 
@@ -88,5 +88,9 @@ public class Question {
 
     public boolean isWriter(User user) {
         return writer.isSameId(user);
+    }
+
+    public boolean canDeleted() {
+        return answers.stream().filter(answer -> !answer.isWriter(this.writer)).count() == 0;
     }
 }

--- a/src/main/java/com/codessquad/qna/entity/Question.java
+++ b/src/main/java/com/codessquad/qna/entity/Question.java
@@ -1,5 +1,7 @@
 package com.codessquad.qna.entity;
 
+import org.hibernate.annotations.Where;
+
 import javax.persistence.*;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -26,7 +28,11 @@ public class Question {
     private LocalDateTime writeDateTime;
 
     @OneToMany(mappedBy = "question")
+    @Where(clause = "deleted = false")
     private List<Answer> answers;
+
+    @Column(nullable = false, columnDefinition = "boolean default false")
+    private boolean deleted;
 
     protected Question() {
     }
@@ -64,6 +70,15 @@ public class Question {
 
     public List<Answer> getAnswers() {
         return answers;
+    }
+
+    public boolean isDeleted() {
+        return this.deleted;
+    }
+
+    public void delete() {
+        answers.stream().forEach(x -> x.delete());
+        this.deleted = true;
     }
 
     public void update(String title, String contents) {

--- a/src/main/java/com/codessquad/qna/entity/Question.java
+++ b/src/main/java/com/codessquad/qna/entity/Question.java
@@ -3,6 +3,7 @@ package com.codessquad.qna.entity;
 import javax.persistence.*;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
 
 @Entity
 @Table(name = "QUESTION")
@@ -23,6 +24,9 @@ public class Question {
 
     @Column(nullable = false)
     private LocalDateTime writeDateTime;
+
+    @OneToMany(mappedBy = "question")
+    private List<Answer> answers;
 
     protected Question() {
     }
@@ -56,6 +60,10 @@ public class Question {
 
     public String getFormattedWriteDateTime() {
         return writeDateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
+    }
+
+    public List<Answer> getAnswers() {
+        return answers;
     }
 
     public void update(String title, String contents) {

--- a/src/main/java/com/codessquad/qna/entity/Question.java
+++ b/src/main/java/com/codessquad/qna/entity/Question.java
@@ -12,7 +12,7 @@ import java.util.List;
 public class Question {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private long id;
+    private Long id;
 
     @ManyToOne
     @JoinColumn(foreignKey = @ForeignKey(name = "fk_question_writer"))

--- a/src/main/java/com/codessquad/qna/entity/Question.java
+++ b/src/main/java/com/codessquad/qna/entity/Question.java
@@ -10,13 +10,17 @@ public class Question {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long id;
+
     @ManyToOne
     @JoinColumn(foreignKey = @ForeignKey(name = "fk_question_writer"))
     private User writer;
+
     @Column(nullable = false, length = 100)
     private String title;
+
     @Column(nullable = false, length = 3000)
     private String contents;
+
     @Column(nullable = false)
     private LocalDateTime writeDateTime;
 

--- a/src/main/java/com/codessquad/qna/entity/User.java
+++ b/src/main/java/com/codessquad/qna/entity/User.java
@@ -61,4 +61,8 @@ public class User {
     public boolean verify(User toVerify) {
         return this.userId.equals(toVerify.userId) && this.password.equals(toVerify.password);
     }
+
+    public boolean isSameId(User user) {
+        return this.userId == user.userId;
+    }
 }

--- a/src/main/java/com/codessquad/qna/entity/User.java
+++ b/src/main/java/com/codessquad/qna/entity/User.java
@@ -63,6 +63,6 @@ public class User {
     }
 
     public boolean isSameId(User user) {
-        return this.userId == user.userId;
+        return this.id.equals(user.id);
     }
 }

--- a/src/main/java/com/codessquad/qna/entity/User.java
+++ b/src/main/java/com/codessquad/qna/entity/User.java
@@ -8,12 +8,16 @@ public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
     @Column(nullable = false, length = 20, unique = true)
     private String userId;
+
     @Column(nullable = false, length = 20)
     private String password;
+
     @Column(nullable = false, length = 20)
     private String name;
+
     @Column(nullable = false, length = 50)
     private String email;
 

--- a/src/main/java/com/codessquad/qna/exception/AnswerNotFoundException.java
+++ b/src/main/java/com/codessquad/qna/exception/AnswerNotFoundException.java
@@ -1,7 +1,0 @@
-package com.codessquad.qna.exception;
-
-public class AnswerNotFoundException extends RuntimeException {
-    public AnswerNotFoundException() {
-        super("해당 Answer를 찾을 수 없습니다.");
-    }
-}

--- a/src/main/java/com/codessquad/qna/exception/AnswerNotFoundException.java
+++ b/src/main/java/com/codessquad/qna/exception/AnswerNotFoundException.java
@@ -1,0 +1,7 @@
+package com.codessquad.qna.exception;
+
+public class AnswerNotFoundException extends RuntimeException {
+    public AnswerNotFoundException() {
+        super("해당 Answer를 찾을 수 없습니다.");
+    }
+}

--- a/src/main/java/com/codessquad/qna/exception/CannotDeleteQuestionException.java
+++ b/src/main/java/com/codessquad/qna/exception/CannotDeleteQuestionException.java
@@ -1,0 +1,7 @@
+package com.codessquad.qna.exception;
+
+public class CannotDeleteQuestionException extends RuntimeException {
+    public CannotDeleteQuestionException() {
+        super("Question 작성자가 아닌 사용자의 답변이 있어서 삭제할 수 없습니다.");
+    }
+}

--- a/src/main/java/com/codessquad/qna/exception/NotAuthorizedException.java
+++ b/src/main/java/com/codessquad/qna/exception/NotAuthorizedException.java
@@ -1,0 +1,7 @@
+package com.codessquad.qna.exception;
+
+public class NotAuthorizedException extends RuntimeException {
+    public NotAuthorizedException() {
+        super("권한이 없습니다.");
+    }
+}

--- a/src/main/java/com/codessquad/qna/exception/NotFoundException.java
+++ b/src/main/java/com/codessquad/qna/exception/NotFoundException.java
@@ -1,0 +1,7 @@
+package com.codessquad.qna.exception;
+
+public class NotFoundException extends RuntimeException {
+    public NotFoundException(String msg) {
+        super(msg);
+    }
+}

--- a/src/main/java/com/codessquad/qna/exception/QuestionNotFoundException.java
+++ b/src/main/java/com/codessquad/qna/exception/QuestionNotFoundException.java
@@ -1,7 +1,0 @@
-package com.codessquad.qna.exception;
-
-public class QuestionNotFoundException extends RuntimeException {
-    public QuestionNotFoundException() {
-        super("해당 Question을 찾을 수 없습니다.");
-    }
-}

--- a/src/main/java/com/codessquad/qna/exception/UserNotFoundException.java
+++ b/src/main/java/com/codessquad/qna/exception/UserNotFoundException.java
@@ -1,7 +1,0 @@
-package com.codessquad.qna.exception;
-
-public class UserNotFoundException extends RuntimeException {
-    public UserNotFoundException() {
-        super("사용자를 찾을 수 없습니다.");
-    }
-}

--- a/src/main/java/com/codessquad/qna/exceptionHandler/GlobalExceptionHandler.java
+++ b/src/main/java/com/codessquad/qna/exceptionHandler/GlobalExceptionHandler.java
@@ -1,9 +1,6 @@
 package com.codessquad.qna.exceptionHandler;
 
-import com.codessquad.qna.exception.NotAuthorizedException;
-import com.codessquad.qna.exception.QuestionNotFoundException;
-import com.codessquad.qna.exception.UserNotFoundException;
-import com.codessquad.qna.exception.UserNotFoundInSessionException;
+import com.codessquad.qna.exception.*;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -14,7 +11,8 @@ import javax.servlet.http.HttpServletResponse;
 public class GlobalExceptionHandler {
     @ExceptionHandler({
             UserNotFoundException.class,
-            QuestionNotFoundException.class
+            QuestionNotFoundException.class,
+            AnswerNotFoundException.class
     })
     public String exceptionPage(RuntimeException ex, Model model) {
         model.addAttribute("errorMessage", ex.getMessage());

--- a/src/main/java/com/codessquad/qna/exceptionHandler/GlobalExceptionHandler.java
+++ b/src/main/java/com/codessquad/qna/exceptionHandler/GlobalExceptionHandler.java
@@ -12,7 +12,8 @@ public class GlobalExceptionHandler {
     @ExceptionHandler({
             UserNotFoundException.class,
             QuestionNotFoundException.class,
-            AnswerNotFoundException.class
+            AnswerNotFoundException.class,
+            CannotDeleteQuestionException.class
     })
     public String exceptionPage(RuntimeException ex, Model model) {
         model.addAttribute("errorMessage", ex.getMessage());

--- a/src/main/java/com/codessquad/qna/exceptionHandler/GlobalExceptionHandler.java
+++ b/src/main/java/com/codessquad/qna/exceptionHandler/GlobalExceptionHandler.java
@@ -14,10 +14,16 @@ import javax.servlet.http.HttpServletResponse;
 public class GlobalExceptionHandler {
     @ExceptionHandler({
             UserNotFoundException.class,
-            QuestionNotFoundException.class,
-            NotAuthorizedException.class
+            QuestionNotFoundException.class
     })
     public String exceptionPage(RuntimeException ex, Model model) {
+        model.addAttribute("errorMessage", ex.getMessage());
+        return "/error/handledError";
+    }
+
+    @ExceptionHandler(NotAuthorizedException.class)
+    public String notAuthorizedException(NotAuthorizedException ex, Model model, HttpServletResponse response) {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         model.addAttribute("errorMessage", ex.getMessage());
         return "/error/handledError";
     }

--- a/src/main/java/com/codessquad/qna/exceptionHandler/GlobalExceptionHandler.java
+++ b/src/main/java/com/codessquad/qna/exceptionHandler/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.codessquad.qna.exceptionHandler;
 
+import com.codessquad.qna.exception.NotAuthorizedException;
 import com.codessquad.qna.exception.QuestionNotFoundException;
 import com.codessquad.qna.exception.UserNotFoundException;
 import com.codessquad.qna.exception.UserNotFoundInSessionException;
@@ -14,7 +15,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler({
             UserNotFoundException.class,
             QuestionNotFoundException.class,
-            IllegalStateException.class
+            NotAuthorizedException.class
     })
     public String exceptionPage(RuntimeException ex, Model model) {
         model.addAttribute("errorMessage", ex.getMessage());

--- a/src/main/java/com/codessquad/qna/repository/AnswerRepository.java
+++ b/src/main/java/com/codessquad/qna/repository/AnswerRepository.java
@@ -1,0 +1,6 @@
+package com.codessquad.qna.repository;
+
+import com.codessquad.qna.entity.Answer;
+
+public interface AnswerRepository extends GenericRepository<Answer, Long> {
+}

--- a/src/main/java/com/codessquad/qna/repository/QuestionRepository.java
+++ b/src/main/java/com/codessquad/qna/repository/QuestionRepository.java
@@ -2,5 +2,8 @@ package com.codessquad.qna.repository;
 
 import com.codessquad.qna.entity.Question;
 
+import java.util.List;
+
 public interface QuestionRepository extends GenericRepository<Question, Long> {
+    List<Question> findAllByAndDeletedFalse();
 }

--- a/src/main/java/com/codessquad/qna/service/AnswerService.java
+++ b/src/main/java/com/codessquad/qna/service/AnswerService.java
@@ -3,6 +3,8 @@ package com.codessquad.qna.service;
 import com.codessquad.qna.entity.Answer;
 import com.codessquad.qna.entity.Question;
 import com.codessquad.qna.entity.User;
+import com.codessquad.qna.exception.AnswerNotFoundException;
+import com.codessquad.qna.exception.NotAuthorizedException;
 import com.codessquad.qna.repository.AnswerRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -21,5 +23,18 @@ public class AnswerService {
     public void addAnswer(long questionId, User writer, String contents) {
         Question question = questionService.getQuestion(questionId);
         answerRepository.save(new Answer(question, writer, contents));
+    }
+
+    public void deleteAnswer(long answerId, User tryToDelete) {
+        Answer answer = getAnswer(answerId);
+        if (answer.isWriter(tryToDelete)) {
+            answerRepository.delete(answer);
+            return;
+        }
+        throw new NotAuthorizedException();
+    }
+
+    public Answer getAnswer(long id) {
+        return answerRepository.findById(id).orElseThrow(AnswerNotFoundException::new);
     }
 }

--- a/src/main/java/com/codessquad/qna/service/AnswerService.java
+++ b/src/main/java/com/codessquad/qna/service/AnswerService.java
@@ -1,0 +1,25 @@
+package com.codessquad.qna.service;
+
+import com.codessquad.qna.entity.Answer;
+import com.codessquad.qna.entity.Question;
+import com.codessquad.qna.entity.User;
+import com.codessquad.qna.repository.AnswerRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AnswerService {
+    private final AnswerRepository answerRepository;
+    private final QuestionService questionService;
+
+    @Autowired
+    public AnswerService(AnswerRepository answerRepository, QuestionService questionService) {
+        this.answerRepository = answerRepository;
+        this.questionService = questionService;
+    }
+
+    public void addAnswer(long questionId, User writer, String contents) {
+        Question question = questionService.getQuestion(questionId);
+        answerRepository.save(new Answer(question, writer, contents));
+    }
+}

--- a/src/main/java/com/codessquad/qna/service/AnswerService.java
+++ b/src/main/java/com/codessquad/qna/service/AnswerService.java
@@ -28,7 +28,8 @@ public class AnswerService {
     public void deleteAnswer(long answerId, User tryToDelete) {
         Answer answer = getAnswer(answerId);
         if (answer.isWriter(tryToDelete)) {
-            answerRepository.delete(answer);
+            answer.delete();
+            answerRepository.save(answer);
             return;
         }
         throw new NotAuthorizedException();

--- a/src/main/java/com/codessquad/qna/service/AnswerService.java
+++ b/src/main/java/com/codessquad/qna/service/AnswerService.java
@@ -3,8 +3,8 @@ package com.codessquad.qna.service;
 import com.codessquad.qna.entity.Answer;
 import com.codessquad.qna.entity.Question;
 import com.codessquad.qna.entity.User;
-import com.codessquad.qna.exception.AnswerNotFoundException;
 import com.codessquad.qna.exception.NotAuthorizedException;
+import com.codessquad.qna.exception.NotFoundException;
 import com.codessquad.qna.repository.AnswerRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -36,6 +36,6 @@ public class AnswerService {
     }
 
     public Answer getAnswer(long id) {
-        return answerRepository.findById(id).orElseThrow(AnswerNotFoundException::new);
+        return answerRepository.findById(id).orElseThrow(() -> new NotFoundException(id + " 답변을 찾을 수 없습니다."));
     }
 }

--- a/src/main/java/com/codessquad/qna/service/QuestionService.java
+++ b/src/main/java/com/codessquad/qna/service/QuestionService.java
@@ -22,15 +22,23 @@ public class QuestionService {
         questionRepository.save(new Question(user, title, contents));
     }
 
-    public void updateQuestion(long questionId, String title, String contents) {
+    public void updateQuestion(long questionId, String title, String contents, User tryToUpdate) {
         Question question = getQuestion(questionId);
-        question.update(title, contents);
-        questionRepository.save(question);
+        if (question.getWriter().getId() == tryToUpdate.getId()) {
+            question.update(title, contents);
+            questionRepository.save(question);
+            return;
+        }
+        throw new IllegalStateException("자신의 글만 수정할 수 있습니다.");
     }
 
-    public void deleteQuestion(long questionId) {
+    public void deleteQuestion(long questionId, User tryToDelete) {
         Question question = getQuestion(questionId);
-        questionRepository.delete(question);
+        if (question.getWriter().getId() == tryToDelete.getId()) {
+            questionRepository.delete(question);
+            return;
+        }
+        throw new IllegalStateException(("자신의 글만 삭제할 수 있습니다."));
     }
 
     public List<Question> getQuestions() {

--- a/src/main/java/com/codessquad/qna/service/QuestionService.java
+++ b/src/main/java/com/codessquad/qna/service/QuestionService.java
@@ -2,6 +2,7 @@ package com.codessquad.qna.service;
 
 import com.codessquad.qna.entity.Question;
 import com.codessquad.qna.entity.User;
+import com.codessquad.qna.exception.NotAuthorizedException;
 import com.codessquad.qna.exception.QuestionNotFoundException;
 import com.codessquad.qna.repository.QuestionRepository;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,7 +30,7 @@ public class QuestionService {
             questionRepository.save(question);
             return;
         }
-        throw new IllegalStateException("자신의 글만 수정할 수 있습니다.");
+        throw new NotAuthorizedException();
     }
 
     public void deleteQuestion(long questionId, User tryToDelete) {
@@ -38,7 +39,7 @@ public class QuestionService {
             questionRepository.delete(question);
             return;
         }
-        throw new IllegalStateException(("자신의 글만 삭제할 수 있습니다."));
+        throw new NotAuthorizedException();
     }
 
     public List<Question> getQuestions() {

--- a/src/main/java/com/codessquad/qna/service/QuestionService.java
+++ b/src/main/java/com/codessquad/qna/service/QuestionService.java
@@ -4,7 +4,7 @@ import com.codessquad.qna.entity.Question;
 import com.codessquad.qna.entity.User;
 import com.codessquad.qna.exception.CannotDeleteQuestionException;
 import com.codessquad.qna.exception.NotAuthorizedException;
-import com.codessquad.qna.exception.QuestionNotFoundException;
+import com.codessquad.qna.exception.NotFoundException;
 import com.codessquad.qna.repository.QuestionRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -54,6 +54,6 @@ public class QuestionService {
     }
 
     public Question getQuestion(long id) {
-        return questionRepository.findById(id).orElseThrow(QuestionNotFoundException::new);
+        return questionRepository.findById(id).orElseThrow(() -> new NotFoundException(id + " 질문을 찾을 수 없습니다."));
     }
 }

--- a/src/main/java/com/codessquad/qna/service/QuestionService.java
+++ b/src/main/java/com/codessquad/qna/service/QuestionService.java
@@ -25,7 +25,7 @@ public class QuestionService {
 
     public void updateQuestion(long questionId, String title, String contents, User tryToUpdate) {
         Question question = getQuestion(questionId);
-        if (question.getWriter().getId() == tryToUpdate.getId()) {
+        if (question.isWriter(tryToUpdate)) {
             question.update(title, contents);
             questionRepository.save(question);
             return;
@@ -35,7 +35,7 @@ public class QuestionService {
 
     public void deleteQuestion(long questionId, User tryToDelete) {
         Question question = getQuestion(questionId);
-        if (question.getWriter().getId() == tryToDelete.getId()) {
+        if (question.isWriter(tryToDelete)) {
             questionRepository.delete(question);
             return;
         }

--- a/src/main/java/com/codessquad/qna/service/QuestionService.java
+++ b/src/main/java/com/codessquad/qna/service/QuestionService.java
@@ -2,6 +2,7 @@ package com.codessquad.qna.service;
 
 import com.codessquad.qna.entity.Question;
 import com.codessquad.qna.entity.User;
+import com.codessquad.qna.exception.CannotDeleteQuestionException;
 import com.codessquad.qna.exception.NotAuthorizedException;
 import com.codessquad.qna.exception.QuestionNotFoundException;
 import com.codessquad.qna.repository.QuestionRepository;
@@ -35,12 +36,17 @@ public class QuestionService {
 
     public void deleteQuestion(long questionId, User tryToDelete) {
         Question question = getQuestion(questionId);
-        if (question.isWriter(tryToDelete)) {
-            question.delete();
-            questionRepository.save(question);
-            return;
+        if (!question.isWriter(tryToDelete)) {
+            throw new NotAuthorizedException();
         }
-        throw new NotAuthorizedException();
+        if (!question.canDeleted()) {
+            throw new CannotDeleteQuestionException();
+        }
+
+        question.delete();
+        questionRepository.save(question);
+        return;
+
     }
 
     public List<Question> getQuestions() {

--- a/src/main/java/com/codessquad/qna/service/QuestionService.java
+++ b/src/main/java/com/codessquad/qna/service/QuestionService.java
@@ -1,6 +1,7 @@
 package com.codessquad.qna.service;
 
 import com.codessquad.qna.entity.Question;
+import com.codessquad.qna.entity.User;
 import com.codessquad.qna.exception.QuestionNotFoundException;
 import com.codessquad.qna.repository.QuestionRepository;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,8 +18,8 @@ public class QuestionService {
         this.questionRepository = questionRepository;
     }
 
-    public void addQuestion(Question question) {
-        questionRepository.save(question);
+    public void addQuestion(User user, String title, String contents) {
+        questionRepository.save(new Question(user, title, contents));
     }
 
     public void updateQuestion(long questionId, String title, String contents) {

--- a/src/main/java/com/codessquad/qna/service/QuestionService.java
+++ b/src/main/java/com/codessquad/qna/service/QuestionService.java
@@ -36,14 +36,15 @@ public class QuestionService {
     public void deleteQuestion(long questionId, User tryToDelete) {
         Question question = getQuestion(questionId);
         if (question.isWriter(tryToDelete)) {
-            questionRepository.delete(question);
+            question.delete();
+            questionRepository.save(question);
             return;
         }
         throw new NotAuthorizedException();
     }
 
     public List<Question> getQuestions() {
-        return questionRepository.findAll();
+        return questionRepository.findAllByAndDeletedFalse();
     }
 
     public Question getQuestion(long id) {

--- a/src/main/java/com/codessquad/qna/service/UserService.java
+++ b/src/main/java/com/codessquad/qna/service/UserService.java
@@ -1,7 +1,7 @@
 package com.codessquad.qna.service;
 
 import com.codessquad.qna.entity.User;
-import com.codessquad.qna.exception.UserNotFoundException;
+import com.codessquad.qna.exception.NotFoundException;
 import com.codessquad.qna.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -31,7 +31,7 @@ public class UserService {
     }
 
     public void updateUser(User user) {
-        User toUpdate = userRepository.findByUserId(user.getUserId()).orElseThrow(UserNotFoundException::new);
+        User toUpdate = userRepository.findByUserId(user.getUserId()).orElseThrow(() -> new NotFoundException("사용자를 찾을 수 없습니다"));
         if (toUpdate.verify(user)) {
             toUpdate.update(user);
             userRepository.save(toUpdate);
@@ -39,10 +39,10 @@ public class UserService {
     }
 
     public User getUser(long id) {
-        return userRepository.findById(id).orElseThrow(UserNotFoundException::new);
+        return userRepository.findById(id).orElseThrow(() -> new NotFoundException(id + " 사용자를 찾을 수 없습니다"));
     }
 
     public User getUser(String userId) {
-        return userRepository.findByUserId(userId).orElseThrow(UserNotFoundException::new);
+        return userRepository.findByUserId(userId).orElseThrow(() -> new NotFoundException("사용자를 찾을 수 없습니다"));
     }
 }

--- a/src/main/java/com/codessquad/qna/util/HttpSessionUtils.java
+++ b/src/main/java/com/codessquad/qna/util/HttpSessionUtils.java
@@ -5,8 +5,11 @@ import com.codessquad.qna.exception.UserNotFoundInSessionException;
 
 import javax.servlet.http.HttpSession;
 
-public class HttpSessionUtil {
+public class HttpSessionUtils {
     public static final String USER_KEY = "sessionedUser";
+
+    private HttpSessionUtils() {
+    }
 
     public static boolean hasUser(HttpSession session) {
         Object userObject = session.getAttribute(USER_KEY);

--- a/src/main/resources/import.sql
+++ b/src/main/resources/import.sql
@@ -1,2 +1,4 @@
 INSERT INTO USER (id, user_id, password, name, email) VALUES (1, 'javajigi', 'test', '자바지기', 'javajigi@slipp.net');
 INSERT INTO USER (id, user_id, password, name, email) VALUES (2, 'sanjigi', 'test', '산지기', 'sanjigi@slipp.net');
+INSERT INTO QUESTION (WRITER_ID, TITLE, CONTENTS, WRITE_DATE_TIME) VALUES (1, '1번 게시물', '1번 게시물입니다', CURRENT_TIMESTAMP);
+INSERT INTO QUESTION (WRITER_ID, TITLE, CONTENTS, WRITE_DATE_TIME) VALUES (2, '2번 게시물', '2번 게시물입니다', CURRENT_TIMESTAMP);

--- a/src/main/resources/templates/qna/list.html
+++ b/src/main/resources/templates/qna/list.html
@@ -13,7 +13,7 @@
                             <div class="auth-info">
                                 <i class="icon-add-comment"></i>
                                 <span class="time">{{formattedWriteDateTime}}</span>
-                                <a href="/user/profile.html" class="author">{{writer.name}}</a>
+                                <a href="/users/{{writer.id}}/profile" class="author">{{writer.name}}</a>
                             </div>
                             <div class="reply" title="댓글">
                                 <i class="icon-reply"></i>

--- a/src/main/resources/templates/qna/show.html
+++ b/src/main/resources/templates/qna/show.html
@@ -44,9 +44,9 @@
 
                 <div class="qna-comment">
                     <div class="qna-comment-slipp">
-                        <p class="qna-comment-count"><strong>2</strong>개의 의견</p>
+                        <p class="qna-comment-count"><strong>{{question.answers.length}}</strong>개의 의견</p>
                         <div class="qna-comment-slipp-articles">
-
+                            {{#question.answers}}
                             <article class="article" id="answer-1405">
                                 <div class="article-header">
                                     <div class="article-header-thumb">
@@ -54,14 +54,14 @@
                                              class="article-author-thumb" alt="">
                                     </div>
                                     <div class="article-header-text">
-                                        <a href="/users/1/자바지기" class="article-author-name">자바지기</a>
+                                        <a href="/users/1/자바지기" class="article-author-name">{{writer.name}}</a>
                                         <a href="#answer-1434" class="article-header-time" title="퍼머링크">
                                             2016-01-12 14:06
                                         </a>
                                     </div>
                                 </div>
                                 <div class="article-doc comment-doc">
-                                    <p>이 글만으로는 원인 파악하기 힘들겠다. 소스 코드와 설정을 단순화해서 공유해 주면 같이 디버깅해줄 수도 있겠다.</p>
+                                    <p>{{contents}}</p>
                                 </div>
                                 <div class="article-util">
                                     <ul class="article-util-list">
@@ -79,38 +79,7 @@
                                     </ul>
                                 </div>
                             </article>
-                            <article class="article" id="answer-1406">
-                                <div class="article-header">
-                                    <div class="article-header-thumb">
-                                        <img src="https://graph.facebook.com/v2.3/1324855987/picture"
-                                             class="article-author-thumb" alt="">
-                                    </div>
-                                    <div class="article-header-text">
-                                        <a href="/users/1/자바지기" class="article-author-name">자바지기</a>
-                                        <a href="#answer-1434" class="article-header-time" title="퍼머링크">
-                                            2016-01-12 14:06
-                                        </a>
-                                    </div>
-                                </div>
-                                <div class="article-doc comment-doc">
-                                    <p>이 글만으로는 원인 파악하기 힘들겠다. 소스 코드와 설정을 단순화해서 공유해 주면 같이 디버깅해줄 수도 있겠다.</p>
-                                </div>
-                                <div class="article-util">
-                                    <ul class="article-util-list">
-                                        <li>
-                                            <a class="link-modify-article"
-                                               href="/questions/413/answers/1405/form">수정</a>
-                                        </li>
-                                        <li>
-                                            <form class="form-delete" action="/questions/413/answers/1405"
-                                                  method="POST">
-                                                <input type="hidden" name="_method" value="DELETE">
-                                                <button type="submit" class="delete-answer-button">삭제</button>
-                                            </form>
-                                        </li>
-                                    </ul>
-                                </div>
-                            </article>
+                            {{/question.answers}}
                             <form class="submit-write">
                                 <div class="form-group" style="padding:14px;">
                                     <textarea class="form-control" placeholder="Update your status"></textarea>

--- a/src/main/resources/templates/qna/show.html
+++ b/src/main/resources/templates/qna/show.html
@@ -70,7 +70,8 @@
                                                href="/questions/413/answers/1405/form">수정</a>
                                         </li>
                                         <li>
-                                            <form class="delete-answer-form" action="/questions/413/answers/1405"
+                                            <form class="delete-answer-form"
+                                                  action="/questions/{{question.id}}/answers/{{id}}"
                                                   method="POST">
                                                 <input type="hidden" name="_method" value="DELETE">
                                                 <button type="submit" class="delete-answer-button">삭제</button>

--- a/src/main/resources/templates/qna/show.html
+++ b/src/main/resources/templates/qna/show.html
@@ -13,7 +13,7 @@
                                  class="article-author-thumb" alt="">
                         </div>
                         <div class="article-header-text">
-                            <a href="/users/92/kimmunsu" class="article-author-name">{{question.writer.name}}</a>
+                            <a href="/users/{{question.writer.id}}/profile" class="article-author-name">{{question.writer.name}}</a>
                             <a href="/questions/413" class="article-header-time" title="퍼머링크">
                                 {{question.formattedWriteDateTime}}
                                 <i class="icon-link"></i>
@@ -54,9 +54,9 @@
                                              class="article-author-thumb" alt="">
                                     </div>
                                     <div class="article-header-text">
-                                        <a href="/users/1/자바지기" class="article-author-name">{{writer.name}}</a>
+                                        <a href="/users/{{writer.id}}/profile" class="article-author-name">{{writer.name}}</a>
                                         <a href="#answer-1434" class="article-header-time" title="퍼머링크">
-                                            2016-01-12 14:06
+                                            {{formattedWriteDateTime}}
                                         </a>
                                     </div>
                                 </div>
@@ -80,11 +80,11 @@
                                 </div>
                             </article>
                             {{/question.answers}}
-                            <form class="submit-write">
+                            <form action="/questions/{{question.id}}/answers/" method="POST">
                                 <div class="form-group" style="padding:14px;">
-                                    <textarea class="form-control" placeholder="Update your status"></textarea>
+                                    <textarea name="contents" class="form-control" placeholder="답변 입력"></textarea>
                                 </div>
-                                <button class="btn btn-success pull-right" type="button">답변하기</button>
+                                <button class="btn btn-success pull-right" type="submit">답변하기</button>
                                 <div class="clearfix"/>
                             </form>
                         </div>


### PR DESCRIPTION
안녕하세요 아이작입니다.
[미션4: 객체-관계 매핑] 과 추가 구현으로 soft deletion까지 구현하였습니다.

직전 미션에서 고민했던 점:
- 직전 미션에서 권한 확인과 같은 비즈니스 로직을 Controller에서 처리해야 할지 Service에서 처리해야 할지 고민했습니다.
- 권한 확인을 위해선 session에서 User 정보를 추출해야 하는데, HttpSession 객체를 Service에 넘기는건 좋은 구현이 아닌 것 같았습니다.
- Service 에는 HTTP layer에 대한 종속성이 없어야 한다고 생각한다는 리뷰어님의 의견도 받았습니다.
- 그래서 직전 미션에서는 controller가 권한 확인을 수행하고 있었습니다.

현재 미션에서 바꾼 점:
- Controller 에서 HttpSessionUtils 를 사용해 User 를 꺼내고 Service로 User 객체를 넘깁니다.
- Service 내부에서는 파라미터로 받은 User 객체를 통해 삭제와 같은 실행의 권한이 있는지 확인합니다.

Soft deletion:
- Soft deletion은 실제 삭제되는 것이 아닌, deleted와 같은 boolean값으로 삭제 여부를 판단합니다.
- Question은 Answer와 OneToMany 관계를 갖는데, JPA가 Question 객체와 맵핑할 때 연결된 Answer 객체도 select하여 Question 객체의 멤버변수로 넣어줍니다.
- deleted가 false인 Answer 객체만 넣어주기 위해서 @OneToMany 아래에 @Where 어노테이션을 추가하였습니다.

항상 좋은 리뷰 감사드립니다.
잘 부탁드립니다.

배포주소 https://glacial-eyrie-85861.herokuapp.com/questions