### PR TITLE
[이노] step 5. XHR과 AJAX

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,8 @@ dependencies {
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	compile 'pl.allegro.tech.boot:handlebars-spring-boot-starter:0.3.2'
 	runtimeOnly 'com.h2database:h2:1.4.192'
+	compile group: 'io.springfox', name: 'springfox-swagger2', version: '2.9.2'
+	compile group: 'io.springfox', name: 'springfox-swagger-ui', version: '2.9.2'
 }
 
 test {

--- a/src/main/java/com/codessquad/qna/QnaApplication.java
+++ b/src/main/java/com/codessquad/qna/QnaApplication.java
@@ -2,8 +2,10 @@ package com.codessquad.qna;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class QnaApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/codessquad/qna/QnaApplication.java
+++ b/src/main/java/com/codessquad/qna/QnaApplication.java
@@ -2,14 +2,40 @@ package com.codessquad.qna;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import springfox.documentation.builders.ApiInfoBuilder;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.service.ApiInfo;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableSwagger2
 public class QnaApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(QnaApplication.class, args);
+	}
+
+	@Bean
+	public Docket api() {
+		return new Docket(DocumentationType.SWAGGER_2)
+				.groupName("QnaApplication")
+				.apiInfo(apiInfo())
+				.select()
+				.paths(PathSelectors.ant("/api/**"))
+				.build();
+	}
+
+	private ApiInfo apiInfo() {
+		return new ApiInfoBuilder()
+				.title("My Qna API")
+				.description("My Qna API")
+				.version("2.0")
+				.build();
 	}
 
 }

--- a/src/main/java/com/codessquad/qna/controller/AnswerController.java
+++ b/src/main/java/com/codessquad/qna/controller/AnswerController.java
@@ -46,7 +46,7 @@ public class AnswerController {
     @DeleteMapping("/answer/{id}")
     public String deleteAnswer(@PathVariable("id") Long id, HttpSession session) {
         this.answerService.delete(id, getUserFromSession(session));
-        logger.info("질문 삭제 요청");
+        logger.info("댓글 삭제 요청");
         return "redirect:/question/" + this.answerService.findQuestionId(id);
     }
 

--- a/src/main/java/com/codessquad/qna/controller/AnswerController.java
+++ b/src/main/java/com/codessquad/qna/controller/AnswerController.java
@@ -23,28 +23,28 @@ public class AnswerController {
     }
 
     @PostMapping("/answer/{questionId}")
-    public String createAnswer(@PathVariable("questionId") Long questionId, Answer answer, HttpSession session) {
+    public String createAnswer(@PathVariable Long questionId, Answer answer, HttpSession session) {
         this.answerService.save(questionId, answer, getUserFromSession(session));
         logger.info("댓글 등록 요청");
         return "redirect:/question/" + questionId;
     }
 
     @GetMapping("/answer/{id}")
-    public String viewUpdateAnswer(@PathVariable("id") Long id, Model model, HttpSession session) {
+    public String viewUpdateAnswer(@PathVariable Long id, Model model, HttpSession session) {
         model.addAttribute("answer", this.answerService.verifyAnswer(id, getUserFromSession(session)));
         logger.info("댓글 수정 페이지 요청");
         return "qna/updateAnswer";
     }
 
     @PutMapping("/answer/{id}")
-    public String updateAnswer(@PathVariable("id") Long id, Answer answer, HttpSession session) {
+    public String updateAnswer(@PathVariable Long id, Answer answer, HttpSession session) {
         this.answerService.update(id, answer, getUserFromSession(session));
         logger.info("댓글 수정 요청");
         return "redirect:/question/" + this.answerService.findQuestionId(id);
     }
 
     @DeleteMapping("/answer/{id}")
-    public String deleteAnswer(@PathVariable("id") Long id, HttpSession session) {
+    public String deleteAnswer(@PathVariable Long id, HttpSession session) {
         this.answerService.delete(id, getUserFromSession(session));
         logger.info("댓글 삭제 요청");
         return "redirect:/question/" + this.answerService.findQuestionId(id);

--- a/src/main/java/com/codessquad/qna/controller/ApiAnswerController.java
+++ b/src/main/java/com/codessquad/qna/controller/ApiAnswerController.java
@@ -4,6 +4,7 @@ import com.codessquad.qna.model.Answer;
 import com.codessquad.qna.service.AnswerService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -22,10 +23,16 @@ public class ApiAnswerController {
         this.answerService = answerService;
     }
 
-    @PostMapping("api/answer/{questionId}")
+    @PostMapping("/api/answer/{questionId}")
     public Answer createAnswer(@PathVariable("questionId") Long questionId, Answer answer, HttpSession session) {
         logger.info("댓글 등록 요청");
         return this.answerService.save(questionId, answer, getUserFromSession(session));
+    }
+
+    @DeleteMapping("/api/answer/{id}")
+    public Answer deleteAnswer(@PathVariable("id") Long id, HttpSession session) {
+        logger.info("댓글 삭제 요청");
+        return this.answerService.delete(id, getUserFromSession(session));
     }
 
 }

--- a/src/main/java/com/codessquad/qna/controller/ApiAnswerController.java
+++ b/src/main/java/com/codessquad/qna/controller/ApiAnswerController.java
@@ -24,13 +24,13 @@ public class ApiAnswerController {
     }
 
     @PostMapping("/api/answer/{questionId}")
-    public Answer createAnswer(@PathVariable("questionId") Long questionId, Answer answer, HttpSession session) {
+    public Answer createAnswer(@PathVariable Long questionId, Answer answer, HttpSession session) {
         logger.info("댓글 등록 요청");
         return this.answerService.save(questionId, answer, getUserFromSession(session));
     }
 
     @DeleteMapping("/api/answer/{id}")
-    public Answer deleteAnswer(@PathVariable("id") Long id, HttpSession session) {
+    public Answer deleteAnswer(@PathVariable Long id, HttpSession session) {
         logger.info("댓글 삭제 요청");
         return this.answerService.delete(id, getUserFromSession(session));
     }

--- a/src/main/java/com/codessquad/qna/controller/ApiAnswerController.java
+++ b/src/main/java/com/codessquad/qna/controller/ApiAnswerController.java
@@ -1,0 +1,31 @@
+package com.codessquad.qna.controller;
+
+import com.codessquad.qna.model.Answer;
+import com.codessquad.qna.service.AnswerService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpSession;
+
+import static com.codessquad.qna.controller.HttpSessionUtils.getUserFromSession;
+
+@RestController
+public class ApiAnswerController {
+
+    private final Logger logger = LoggerFactory.getLogger(AnswerController.class);
+    private final AnswerService answerService;
+
+    public ApiAnswerController(AnswerService answerService) {
+        this.answerService = answerService;
+    }
+
+    @PostMapping("api/answer/{questionId}")
+    public Answer createAnswer(@PathVariable("questionId") Long questionId, Answer answer, HttpSession session) {
+        logger.info("댓글 등록 요청");
+        return this.answerService.save(questionId, answer, getUserFromSession(session));
+    }
+
+}

--- a/src/main/java/com/codessquad/qna/controller/HttpSessionUtils.java
+++ b/src/main/java/com/codessquad/qna/controller/HttpSessionUtils.java
@@ -1,5 +1,6 @@
 package com.codessquad.qna.controller;
 
+import com.codessquad.qna.exception.ErrorMessage;
 import com.codessquad.qna.exception.UserSessionException;
 import com.codessquad.qna.model.User;
 
@@ -15,7 +16,7 @@ public class HttpSessionUtils {
 
     public static User getUserFromSession(HttpSession session) {
         if (!isLoginUser(session)) {
-            throw new UserSessionException();
+            throw new UserSessionException(ErrorMessage.NEED_LOGIN);
         }
         return (User) session.getAttribute(USER_SESSION_KEY);
     }

--- a/src/main/java/com/codessquad/qna/controller/QuestionController.java
+++ b/src/main/java/com/codessquad/qna/controller/QuestionController.java
@@ -45,28 +45,28 @@ public class QuestionController {
     }
 
     @GetMapping("/question/{id}")
-    public String viewQuestion(@PathVariable("id") Long id, Model model) {
+    public String viewQuestion(@PathVariable Long id, Model model) {
         model.addAttribute("question", this.questionService.findById(id));
         logger.info("상세 질문 페이지 요청");
         return "qna/show";
     }
 
     @GetMapping("/question/{id}/form")
-    public String viewUpdateQuestion(@PathVariable("id") Long id, Model model, HttpSession session) {
+    public String viewUpdateQuestion(@PathVariable Long id, Model model, HttpSession session) {
         model.addAttribute("question", this.questionService.verifyQuestion(id, getUserFromSession(session)));
         logger.info("질문 수정 페이지 요청");
         return "qna/updateForm";
     }
 
     @PutMapping("/question/{id}/form")
-    public String updateQuestion(@PathVariable("id") Long id, Question question, HttpSession session) {
+    public String updateQuestion(@PathVariable Long id, Question question, HttpSession session) {
         this.questionService.update(id, question, getUserFromSession(session));
         logger.info("질문 수정 요청");
         return "redirect:/question/" + id;
     }
 
     @DeleteMapping("/question/{id}")
-    public String deleteQuestion(@PathVariable("id") Long id, HttpSession session) {
+    public String deleteQuestion(@PathVariable Long id, HttpSession session) {
         boolean result = this.questionService.delete(id, getUserFromSession(session));
         logger.info("질문 삭제 요청");
         return result ? "redirect:/" : "redirect:/question/" + id;

--- a/src/main/java/com/codessquad/qna/controller/UserController.java
+++ b/src/main/java/com/codessquad/qna/controller/UserController.java
@@ -2,7 +2,6 @@ package com.codessquad.qna.controller;
 
 import com.codessquad.qna.model.User;
 import com.codessquad.qna.service.UserService;
-import org.omg.CORBA.Request;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Controller;
@@ -72,21 +71,21 @@ public class UserController {
     }
 
     @GetMapping("/user/{userId}/profile")
-    public String viewProfile(@PathVariable("userId") String userId, Model model) {
+    public String viewProfile(@PathVariable String userId, Model model) {
         model.addAttribute("user", this.userService.findByUserId(userId));
         logger.info("유저 프로필 페이지 요청");
         return "user/profile";
     }
 
     @GetMapping("/user/{id}/form")
-    public String viewUpdateProfile(@PathVariable("id") Long id, Model model, HttpSession session) {
+    public String viewUpdateProfile(@PathVariable Long id, Model model, HttpSession session) {
         model.addAttribute("user", this.userService.verifyUser(id, getUserFromSession(session)));
         logger.info("유저 정보 수정 페이지 요청");
         return "user/updateForm";
     }
 
     @PutMapping("/user/{id}/form")
-    public String updateProfile(@PathVariable("id") Long id, User user, String oldPassword, HttpServletRequest request, HttpSession session) {
+    public String updateProfile(@PathVariable Long id, User user, String oldPassword, HttpServletRequest request, HttpSession session) {
         request.setAttribute("path", "/user/updateForm");
         this.userService.update(id, user, oldPassword, getUserFromSession(session));
         logger.info("유저 정보 수정 요청");

--- a/src/main/java/com/codessquad/qna/controller/UserController.java
+++ b/src/main/java/com/codessquad/qna/controller/UserController.java
@@ -11,7 +11,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 
-import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 
 import static com.codessquad.qna.controller.HttpSessionUtils.USER_SESSION_KEY;
@@ -35,8 +34,7 @@ public class UserController {
     }
 
     @PostMapping("/user/form")
-    public String signUp(User user, HttpServletRequest request) {
-        request.setAttribute("path", "/user/form");
+    public String signUp(User user) {
         this.userService.save(user);
         logger.info("회원가입 요청");
         return "redirect:/user/list";
@@ -49,8 +47,7 @@ public class UserController {
     }
 
     @PostMapping("/user/login")
-    public String login(String userId, String password, HttpServletRequest request, HttpSession session) {
-        request.setAttribute("path", "/user/login");
+    public String login(String userId, String password, HttpSession session) {
         session.setAttribute(USER_SESSION_KEY, this.userService.login(userId, password));
         logger.info("로그인 요청");
         return "redirect:/";
@@ -85,8 +82,7 @@ public class UserController {
     }
 
     @PutMapping("/user/{id}/form")
-    public String updateProfile(@PathVariable Long id, User user, String oldPassword, HttpServletRequest request, HttpSession session) {
-        request.setAttribute("path", "/user/updateForm");
+    public String updateProfile(@PathVariable Long id, User user, String oldPassword, HttpSession session) {
         this.userService.update(id, user, oldPassword, getUserFromSession(session));
         logger.info("유저 정보 수정 요청");
         return "redirect:/user/list";

--- a/src/main/java/com/codessquad/qna/exception/EntityNotFoundException.java
+++ b/src/main/java/com/codessquad/qna/exception/EntityNotFoundException.java
@@ -1,0 +1,9 @@
+package com.codessquad.qna.exception;
+
+public class EntityNotFoundException extends RuntimeException {
+
+    public EntityNotFoundException(ErrorMessage errorMessage) {
+        super(errorMessage.getErrorMessage());
+    }
+
+}

--- a/src/main/java/com/codessquad/qna/exception/ErrorMessage.java
+++ b/src/main/java/com/codessquad/qna/exception/ErrorMessage.java
@@ -1,0 +1,24 @@
+package com.codessquad.qna.exception;
+
+public enum ErrorMessage {
+
+    USER_NOT_FOUND("해당 유저를 찾을 수 없습니다."),
+    QUESTION_NOT_FOUND("해당 질문을 찾을 수 없습니다."),
+    ANSWER_NOT_FOUND("해당 답변을 찾을 수 없습니다."),
+    NEED_LOGIN("로그인이 필요한 서비스입니다."),
+    INVALID_USER("접근 권한이 없는 유저입니다."),
+    DUPLICATED_ID("이미 사용중인 아이디입니다."),
+    LOGIN_FAILED("아이디 또는 비밀번호가 틀립니다. 다시 로그인 해주세요."),
+    WRONG_PASSWORD("기존 비밀번호가 일치하지 않습니다.");
+
+    private final String errorMessage;
+
+    ErrorMessage(String errorMessage) {
+        this.errorMessage = errorMessage;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+}

--- a/src/main/java/com/codessquad/qna/exception/ErrorMessage.java
+++ b/src/main/java/com/codessquad/qna/exception/ErrorMessage.java
@@ -6,7 +6,7 @@ public enum ErrorMessage {
     QUESTION_NOT_FOUND("해당 질문을 찾을 수 없습니다."),
     ANSWER_NOT_FOUND("해당 답변을 찾을 수 없습니다."),
     NEED_LOGIN("로그인이 필요한 서비스입니다."),
-    INVALID_USER("접근 권한이 없는 유저입니다."),
+    ILLEGAL_USER("접근 권한이 없는 유저입니다."),
     DUPLICATED_ID("이미 사용중인 아이디입니다."),
     LOGIN_FAILED("아이디 또는 비밀번호가 틀립니다. 다시 로그인 해주세요."),
     WRONG_PASSWORD("기존 비밀번호가 일치하지 않습니다.");

--- a/src/main/java/com/codessquad/qna/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/codessquad/qna/exception/GlobalExceptionHandler.java
@@ -6,17 +6,15 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
-import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 
 import static com.codessquad.qna.controller.HttpSessionUtils.getUserFromSession;
-import static com.codessquad.qna.controller.HttpSessionUtils.isLoginUser;
 
 @ControllerAdvice
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(NotFoundException.class)
-    private String handleNotFoundException() {
+    @ExceptionHandler(EntityNotFoundException.class)
+    private String handleEntityNotFoundException() {
         return "redirect:/";
     }
 
@@ -28,12 +26,19 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(UserAccountException.class)
-    private String handleUserAccountException(Model model, HttpSession session, HttpServletRequest request, UserAccountException e) {
+    private String handleUserAccountException(Model model, HttpSession session,  UserAccountException e) {
         model.addAttribute("errorMessage", e.getMessage());
-        if (isLoginUser(session)) {
-            model.addAttribute("user", getUserFromSession(session));
+        switch (e.getErrorMessage()) {
+            case DUPLICATED_ID:
+                return "/user/form";
+            case LOGIN_FAILED:
+                return "/user/login";
+            case WRONG_PASSWORD:
+                model.addAttribute("user", getUserFromSession(session));
+                return "/user/updateForm";
+            default:
+                return "/";
         }
-        return (String) request.getAttribute("path");
     }
 
 }

--- a/src/main/java/com/codessquad/qna/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/codessquad/qna/exception/GlobalExceptionHandler.java
@@ -1,8 +1,10 @@
 package com.codessquad.qna.exception;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
@@ -18,6 +20,7 @@ public class GlobalExceptionHandler {
         return "redirect:/";
     }
 
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
     @ExceptionHandler(UserSessionException.class)
     private String handleUserSessionException(Model model, UserSessionException e) {
         model.addAttribute("errorMessage", e.getMessage());

--- a/src/main/java/com/codessquad/qna/exception/NotFoundException.java
+++ b/src/main/java/com/codessquad/qna/exception/NotFoundException.java
@@ -1,9 +1,0 @@
-package com.codessquad.qna.exception;
-
-public class NotFoundException extends RuntimeException {
-
-    public NotFoundException() {
-        super("해당 정보를 찾을 수 없습니다.");
-    }
-
-}

--- a/src/main/java/com/codessquad/qna/exception/UserAccountException.java
+++ b/src/main/java/com/codessquad/qna/exception/UserAccountException.java
@@ -2,8 +2,15 @@ package com.codessquad.qna.exception;
 
 public class UserAccountException extends RuntimeException {
 
-    public UserAccountException(String errorMessage) {
-        super(errorMessage);
+    private ErrorMessage errorMessage;
+
+    public UserAccountException(ErrorMessage errorMessage) {
+        super(errorMessage.getErrorMessage());
+        this.errorMessage = errorMessage;
+    }
+
+    public ErrorMessage getErrorMessage() {
+        return errorMessage;
     }
 
 }

--- a/src/main/java/com/codessquad/qna/exception/UserSessionException.java
+++ b/src/main/java/com/codessquad/qna/exception/UserSessionException.java
@@ -2,8 +2,8 @@ package com.codessquad.qna.exception;
 
 public class UserSessionException extends RuntimeException {
 
-    public UserSessionException() {
-        super("접근권한이 없는 사용자입니다.");
+    public UserSessionException(ErrorMessage errorMessage) {
+        super(errorMessage.getErrorMessage());
     }
 
 }

--- a/src/main/java/com/codessquad/qna/model/AbstractEntity.java
+++ b/src/main/java/com/codessquad/qna/model/AbstractEntity.java
@@ -1,0 +1,63 @@
+package com.codessquad.qna.model;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.EntityListeners;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.MappedSuperclass;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class AbstractEntity {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @CreatedDate
+    private Date createDate;
+
+    @LastModifiedDate
+    private Date modifiedDate;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String formatDate(Date date, String format) {
+        return new SimpleDateFormat(format).format(date);
+    }
+
+    public String getCreateDate() {
+        return formatDate(this.createDate, "yyyy-MM-dd HH:mm");
+    }
+
+    public void setCreateDate(Date createDate) {
+        this.createDate = createDate;
+    }
+
+    public String getModifiedDate() {
+        return formatDate(this.modifiedDate, "yyyy-MM-dd HH:mm");
+    }
+
+    public void setModifiedDate(Date modifiedDate) {
+        this.modifiedDate = modifiedDate;
+    }
+
+    @Override
+    public String toString() {
+        return "id: " + this.id + ", " +
+                "createDate: " + this.createDate + ", " +
+                "modifiedDate: " + this.modifiedDate;
+    }
+
+}

--- a/src/main/java/com/codessquad/qna/model/Answer.java
+++ b/src/main/java/com/codessquad/qna/model/Answer.java
@@ -47,7 +47,7 @@ public class Answer {
     }
 
     public void update(Answer answer) {
-        this.contents = answer.getContents();
+        this.contents = answer.contents;
         this.date = new Date();
     }
 

--- a/src/main/java/com/codessquad/qna/model/Answer.java
+++ b/src/main/java/com/codessquad/qna/model/Answer.java
@@ -4,15 +4,9 @@ import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 
 import javax.persistence.*;
-import java.text.SimpleDateFormat;
-import java.util.Date;
 
 @Entity
-public class Answer {
-
-    @Id
-    @GeneratedValue
-    private Long id;
+public class Answer extends AbstractEntity {
 
     @ManyToOne
     @JoinColumn(foreignKey = @ForeignKey(name = "fk_answer_to_user"), nullable = false)
@@ -20,9 +14,6 @@ public class Answer {
 
     @Column(nullable = false)
     private String contents;
-
-    @Column(nullable = false)
-    private Date date;
 
     @Column(columnDefinition = "boolean default false")
     private boolean deleted;
@@ -42,25 +33,15 @@ public class Answer {
 
     public void save(User writer, Question question) {
         this.writer = writer;
-        this.date = new Date();
         this.question = question;
     }
 
     public void update(Answer answer) {
         this.contents = answer.contents;
-        this.date = new Date();
     }
 
     public void delete() {
         this.deleted = true;
-    }
-
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
     }
 
     public User getWriter() {
@@ -77,15 +58,6 @@ public class Answer {
 
     public void setContents(String contents) {
         this.contents = contents;
-    }
-
-    public String getDate() {
-        SimpleDateFormat simpleDate = new SimpleDateFormat( "yyyy-MM-dd HH:mm");
-        return simpleDate.format(this.date);
-    }
-
-    public void setDate(Date date) {
-        this.date = date;
     }
 
     public boolean isDeleted() {
@@ -106,9 +78,9 @@ public class Answer {
 
     @Override
     public String toString() {
-        return "writer: " + this.writer.getUserId() + ", " +
+        return super.toString() + ", " +
+                "writer: " + this.writer.getUserId() + ", " +
                 "contents: " + this.contents + ", " +
-                "date: " + this.date + ", " +
                 "question: " + this.question.getId() + ", ";
     }
 

--- a/src/main/java/com/codessquad/qna/model/Answer.java
+++ b/src/main/java/com/codessquad/qna/model/Answer.java
@@ -23,14 +23,6 @@ public class Answer extends AbstractEntity {
     @JoinColumn(foreignKey = @ForeignKey(name = "fk_answer_to_question"), nullable = false)
     private Question question;
 
-    public boolean matchWriter(User loginUser) {
-        return this.writer.matchId(loginUser.getId());
-    }
-
-    public Long getQuestionId() {
-        return this.question.getId();
-    }
-
     public void save(User writer, Question question) {
         this.writer = writer;
         this.question = question;
@@ -42,6 +34,14 @@ public class Answer extends AbstractEntity {
 
     public void delete() {
         this.deleted = true;
+    }
+
+    public boolean matchWriter(User loginUser) {
+        return this.writer.matchId(loginUser.getId());
+    }
+
+    public Long getQuestionId() {
+        return this.question.getId();
     }
 
     public User getWriter() {

--- a/src/main/java/com/codessquad/qna/model/Question.java
+++ b/src/main/java/com/codessquad/qna/model/Question.java
@@ -54,8 +54,8 @@ public class Question {
     }
 
     public void update(Question question) {
-        this.title = question.getTitle();
-        this.contents = question.getContents();
+        this.title = question.title;
+        this.contents = question.contents;
         this.date = new Date();
     }
 

--- a/src/main/java/com/codessquad/qna/model/Question.java
+++ b/src/main/java/com/codessquad/qna/model/Question.java
@@ -37,7 +37,7 @@ public class Question extends AbstractEntity {
     }
 
     public boolean delete() {
-        if (matchWriterOfAnswerList()) {
+        if (countMismatchAnswers() != 0) {
             return false;
         }
         this.deleted = true;
@@ -49,11 +49,10 @@ public class Question extends AbstractEntity {
         return this.writer.matchId(writer.getId());
     }
 
-    public boolean matchWriterOfAnswerList() {
-        long answerCount = getAnswers().stream()
+    public int countMismatchAnswers() {
+        return (int )getAnswers().stream()
                 .filter(answer -> !answer.matchWriter(this.writer))
                 .count();
-        return answerCount == 0;
     }
 
     public User getWriter() {

--- a/src/main/java/com/codessquad/qna/model/Question.java
+++ b/src/main/java/com/codessquad/qna/model/Question.java
@@ -27,18 +27,6 @@ public class Question extends AbstractEntity {
     @OrderBy("id DESC")
     private List<Answer> answers;
 
-    public boolean matchWriter(User writer) {
-        return this.writer.matchId(writer.getId());
-    }
-
-    public boolean matchWriterOfAnswerList() {
-        Long writerId = this.writer.getId();
-        long answerCount = getAnswers().stream()
-                .filter(answer -> !answer.getWriter().matchId(writerId))
-                .count();
-        return answerCount == 0;
-    }
-
     public void save(User writer) {
         this.writer = writer;
     }
@@ -48,9 +36,24 @@ public class Question extends AbstractEntity {
         this.contents = question.contents;
     }
 
-    public void delete() {
+    public boolean delete() {
+        if (matchWriterOfAnswerList()) {
+            return false;
+        }
         this.deleted = true;
         this.answers.forEach(Answer::delete);
+        return true;
+    }
+
+    public boolean matchWriter(User writer) {
+        return this.writer.matchId(writer.getId());
+    }
+
+    public boolean matchWriterOfAnswerList() {
+        long answerCount = getAnswers().stream()
+                .filter(answer -> !answer.matchWriter(this.writer))
+                .count();
+        return answerCount == 0;
     }
 
     public User getWriter() {

--- a/src/main/java/com/codessquad/qna/model/Question.java
+++ b/src/main/java/com/codessquad/qna/model/Question.java
@@ -1,5 +1,7 @@
 package com.codessquad.qna.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import javax.persistence.*;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -29,6 +31,7 @@ public class Question {
     @Column(columnDefinition = "boolean default false")
     private boolean deleted;
 
+    @JsonIgnore
     @OneToMany(mappedBy = "question", cascade = CascadeType.REMOVE)
     private List<Answer> answers;
 

--- a/src/main/java/com/codessquad/qna/model/Question.java
+++ b/src/main/java/com/codessquad/qna/model/Question.java
@@ -3,17 +3,11 @@ package com.codessquad.qna.model;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import javax.persistence.*;
-import java.text.SimpleDateFormat;
-import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Entity
-public class Question {
-
-    @Id
-    @GeneratedValue
-    private Long id;
+public class Question extends AbstractEntity {
 
     @ManyToOne
     @JoinColumn(foreignKey = @ForeignKey(name = "fk_question_to_user"), nullable = false)
@@ -24,9 +18,6 @@ public class Question {
 
     @Column(nullable = false)
     private String contents;
-
-    @Column(nullable = false)
-    private Date date;
 
     @Column(columnDefinition = "boolean default false")
     private boolean deleted;
@@ -50,26 +41,16 @@ public class Question {
 
     public void save(User writer) {
         this.writer = writer;
-        this.date = new Date();
     }
 
     public void update(Question question) {
         this.title = question.title;
         this.contents = question.contents;
-        this.date = new Date();
     }
 
     public void delete() {
         this.deleted = true;
         this.answers.forEach(Answer::delete);
-    }
-
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
     }
 
     public User getWriter() {
@@ -96,15 +77,6 @@ public class Question {
         this.contents = contents;
     }
 
-    public String getDate() {
-        SimpleDateFormat simpleDate = new SimpleDateFormat( "yyyy-MM-dd HH:mm");
-        return simpleDate.format(this.date);
-    }
-
-    public void setDate(Date date) {
-        this.date = date;
-    }
-
     public boolean isDeleted() {
         return deleted;
     }
@@ -125,10 +97,10 @@ public class Question {
 
     @Override
     public String toString() {
-        return "writer: " + this.writer.getUserId() + ", " +
+        return super.toString() + ", " +
+                "writer: " + this.writer.getUserId() + ", " +
                 "title: " + this.title + ", " +
-                "contents: " + this.contents + ", " +
-                "date: " + this.date;
+                "contents: " + this.contents + ", ";
     }
 
 }

--- a/src/main/java/com/codessquad/qna/model/Question.java
+++ b/src/main/java/com/codessquad/qna/model/Question.java
@@ -33,6 +33,7 @@ public class Question {
 
     @JsonIgnore
     @OneToMany(mappedBy = "question", cascade = CascadeType.REMOVE)
+    @OrderBy("id DESC")
     private List<Answer> answers;
 
     public boolean matchWriter(User writer) {

--- a/src/main/java/com/codessquad/qna/model/User.java
+++ b/src/main/java/com/codessquad/qna/model/User.java
@@ -4,15 +4,9 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
 
 @Entity
-public class User {
-
-    @Id
-    @GeneratedValue
-    private Long id;
+public class User extends AbstractEntity {
 
     @Column(nullable = false, unique = true)
     private String userId;
@@ -28,7 +22,7 @@ public class User {
     private String email;
 
     public boolean matchId(Long id) {
-        return this.id.equals(id);
+        return this.getId().equals(id);
     }
 
     public boolean matchPassword(String password) {
@@ -39,14 +33,6 @@ public class User {
         this.password = user.password;
         this.name = user.name;
         this.email = user.email;
-    }
-
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
     }
 
     public String getUserId() {
@@ -83,7 +69,8 @@ public class User {
 
     @Override
     public String toString() {
-        return "userId: " + this.userId + ", " +
+        return super.toString() + ", " +
+                "userId: " + this.userId + ", " +
                 "password: " + this.password + ", " +
                 "name: " + this.name + ", " +
                 "email: " + this.email;

--- a/src/main/java/com/codessquad/qna/model/User.java
+++ b/src/main/java/com/codessquad/qna/model/User.java
@@ -21,18 +21,18 @@ public class User extends AbstractEntity {
     @Column(nullable = false)
     private String email;
 
+    public void update(User user) {
+        this.password = user.password;
+        this.name = user.name;
+        this.email = user.email;
+    }
+
     public boolean matchId(Long id) {
         return this.getId().equals(id);
     }
 
     public boolean matchPassword(String password) {
         return this.password.equals(password);
-    }
-
-    public void update(User user) {
-        this.password = user.password;
-        this.name = user.name;
-        this.email = user.email;
     }
 
     public String getUserId() {

--- a/src/main/java/com/codessquad/qna/model/User.java
+++ b/src/main/java/com/codessquad/qna/model/User.java
@@ -36,9 +36,9 @@ public class User {
     }
 
     public void update(User user) {
-        this.password = user.getPassword();
-        this.name = user.getName();
-        this.email = user.getEmail();
+        this.password = user.password;
+        this.name = user.name;
+        this.email = user.email;
     }
 
     public Long getId() {

--- a/src/main/java/com/codessquad/qna/model/User.java
+++ b/src/main/java/com/codessquad/qna/model/User.java
@@ -1,5 +1,7 @@
 package com.codessquad.qna.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -15,6 +17,7 @@ public class User {
     @Column(nullable = false, unique = true)
     private String userId;
 
+    @JsonIgnore
     @Column(nullable = false)
     private String password;
 

--- a/src/main/java/com/codessquad/qna/service/AnswerService.java
+++ b/src/main/java/com/codessquad/qna/service/AnswerService.java
@@ -29,10 +29,10 @@ public class AnswerService {
         this.answerRepository.save(targetAnswer);
     }
 
-    public void delete(Long id, User sessionUser) {
+    public Answer delete(Long id, User sessionUser) {
         Answer targetAnswer = verifyAnswer(id, sessionUser);
         targetAnswer.delete();
-        this.answerRepository.save(targetAnswer);
+        return this.answerRepository.save(targetAnswer);
     }
 
     public Answer verifyAnswer(Long id, User sessionUser) {

--- a/src/main/java/com/codessquad/qna/service/AnswerService.java
+++ b/src/main/java/com/codessquad/qna/service/AnswerService.java
@@ -18,9 +18,9 @@ public class AnswerService {
         this.questionService = questionService;
     }
 
-    public void save(Long id, Answer answer, User sessionUser) {
+    public Answer save(Long id, Answer answer, User sessionUser) {
         answer.save(sessionUser, questionService.findById(id));
-        this.answerRepository.save(answer);
+        return this.answerRepository.save(answer);
     }
 
     public void update(Long id, Answer answer, User sessionUser) {

--- a/src/main/java/com/codessquad/qna/service/AnswerService.java
+++ b/src/main/java/com/codessquad/qna/service/AnswerService.java
@@ -4,23 +4,27 @@ import com.codessquad.qna.exception.EntityNotFoundException;
 import com.codessquad.qna.exception.ErrorMessage;
 import com.codessquad.qna.exception.UserSessionException;
 import com.codessquad.qna.model.Answer;
+import com.codessquad.qna.model.Question;
 import com.codessquad.qna.model.User;
 import com.codessquad.qna.repository.AnswerRepository;
+import com.codessquad.qna.repository.QuestionRepository;
 import org.springframework.stereotype.Service;
 
 @Service
 public class AnswerService {
 
     private final AnswerRepository answerRepository;
-    private final QuestionService questionService;
+    private final QuestionRepository questionRepository;
 
-    public AnswerService(AnswerRepository answerRepository, QuestionService questionService) {
+    public AnswerService(AnswerRepository answerRepository, QuestionRepository questionRepository) {
         this.answerRepository = answerRepository;
-        this.questionService = questionService;
+        this.questionRepository = questionRepository;
     }
 
     public Answer save(Long id, Answer answer, User sessionUser) {
-        answer.save(sessionUser, questionService.findById(id));
+        Question question = this.questionRepository.findByIdAndDeletedFalse(id).orElseThrow(() ->
+                new EntityNotFoundException(ErrorMessage.QUESTION_NOT_FOUND));
+        answer.save(sessionUser, question);
         return this.answerRepository.save(answer);
     }
 
@@ -44,14 +48,13 @@ public class AnswerService {
         return targetAnswer;
     }
 
-    public Answer findById(Long id) {
-        return this.answerRepository.findByIdAndDeletedFalse(id).orElseThrow(() ->
-                new EntityNotFoundException(ErrorMessage.ANSWER_NOT_FOUND)
-        );
-    }
-
     public Long findQuestionId(Long answerId) {
         return findById(answerId).getQuestionId();
+    }
+
+    public Answer findById(Long id) {
+        return this.answerRepository.findByIdAndDeletedFalse(id).orElseThrow(() ->
+                new EntityNotFoundException(ErrorMessage.ANSWER_NOT_FOUND));
     }
 
 }

--- a/src/main/java/com/codessquad/qna/service/AnswerService.java
+++ b/src/main/java/com/codessquad/qna/service/AnswerService.java
@@ -1,6 +1,7 @@
 package com.codessquad.qna.service;
 
-import com.codessquad.qna.exception.NotFoundException;
+import com.codessquad.qna.exception.EntityNotFoundException;
+import com.codessquad.qna.exception.ErrorMessage;
 import com.codessquad.qna.exception.UserSessionException;
 import com.codessquad.qna.model.Answer;
 import com.codessquad.qna.model.User;
@@ -38,13 +39,15 @@ public class AnswerService {
     public Answer verifyAnswer(Long id, User sessionUser) {
         Answer targetAnswer = findById(id);
         if (!targetAnswer.matchWriter(sessionUser)) {
-            throw new UserSessionException();
+            throw new UserSessionException(ErrorMessage.ILLEGAL_USER);
         }
         return targetAnswer;
     }
 
     public Answer findById(Long id) {
-        return this.answerRepository.findByIdAndDeletedFalse(id).orElseThrow(NotFoundException::new);
+        return this.answerRepository.findByIdAndDeletedFalse(id).orElseThrow(() ->
+                new EntityNotFoundException(ErrorMessage.ANSWER_NOT_FOUND)
+        );
     }
 
     public Long findQuestionId(Long answerId) {

--- a/src/main/java/com/codessquad/qna/service/QuestionService.java
+++ b/src/main/java/com/codessquad/qna/service/QuestionService.java
@@ -32,8 +32,8 @@ public class QuestionService {
 
     public boolean delete(Long id, User sessionUser) {
         Question targetQuestion = verifyQuestion(id, sessionUser);
-        if (targetQuestion.matchWriterOfAnswerList()) {
-            targetQuestion.delete();
+        boolean result = targetQuestion.delete();
+        if (result) {
             this.questionRepository.save(targetQuestion);
             return true;
         }
@@ -54,8 +54,7 @@ public class QuestionService {
 
     public Question findById(Long id) {
         return this.questionRepository.findByIdAndDeletedFalse(id).orElseThrow(() ->
-                new EntityNotFoundException(ErrorMessage.QUESTION_NOT_FOUND)
-        );
+                new EntityNotFoundException(ErrorMessage.QUESTION_NOT_FOUND));
     }
 
 }

--- a/src/main/java/com/codessquad/qna/service/QuestionService.java
+++ b/src/main/java/com/codessquad/qna/service/QuestionService.java
@@ -1,6 +1,7 @@
 package com.codessquad.qna.service;
 
-import com.codessquad.qna.exception.NotFoundException;
+import com.codessquad.qna.exception.EntityNotFoundException;
+import com.codessquad.qna.exception.ErrorMessage;
 import com.codessquad.qna.exception.UserSessionException;
 import com.codessquad.qna.model.Question;
 import com.codessquad.qna.model.User;
@@ -42,7 +43,7 @@ public class QuestionService {
     public Question verifyQuestion(Long id, User sessionUser) {
         Question question = findById(id);
         if (!question.matchWriter(sessionUser)) {
-            throw new UserSessionException();
+            throw new UserSessionException(ErrorMessage.ILLEGAL_USER);
         }
         return question;
     }
@@ -52,7 +53,9 @@ public class QuestionService {
     }
 
     public Question findById(Long id) {
-        return this.questionRepository.findByIdAndDeletedFalse(id).orElseThrow(NotFoundException::new);
+        return this.questionRepository.findByIdAndDeletedFalse(id).orElseThrow(() ->
+                new EntityNotFoundException(ErrorMessage.QUESTION_NOT_FOUND)
+        );
     }
 
 }

--- a/src/main/java/com/codessquad/qna/service/UserService.java
+++ b/src/main/java/com/codessquad/qna/service/UserService.java
@@ -53,8 +53,7 @@ public class UserService {
 
     public User findByUserId(String userId) {
         return this.userRepository.findByUserId(userId).orElseThrow(() ->
-                new EntityNotFoundException(ErrorMessage.USER_NOT_FOUND)
-        );
+                new EntityNotFoundException(ErrorMessage.USER_NOT_FOUND));
     }
 
 }

--- a/src/main/java/com/codessquad/qna/service/UserService.java
+++ b/src/main/java/com/codessquad/qna/service/UserService.java
@@ -19,20 +19,20 @@ public class UserService {
 
     public void save(User user) {
         if (this.userRepository.findByUserId(user.getUserId()).isPresent()) {
-            throw new UserAccountException("이미 사용 중인 아이디입니다.");
+            throw new UserAccountException(ErrorMessage.DUPLICATED_ID);
         }
         this.userRepository.save(user);
     }
 
     public User login(String userId, String password) {
         return this.userRepository.findByUserIdAndPassword(userId, password).orElseThrow(() ->
-                new UserAccountException("아이디 또는 비밀번호가 일치하지 않습니다."));
+                new UserAccountException(ErrorMessage.LOGIN_FAILED));
     }
 
     public void update(Long id, User user, String oldPassword, User sessionUser) {
         User loginUser = verifyUser(id, sessionUser);
         if (!loginUser.matchPassword(oldPassword)) {
-            throw new UserAccountException("기존 비밀번호가 일치하지 않습니다.");
+            throw new UserAccountException(ErrorMessage.WRONG_PASSWORD);
         }
         loginUser.update(user);
         this.userRepository.save(loginUser);
@@ -40,7 +40,7 @@ public class UserService {
 
     public User verifyUser(Long id, User sessionUser) {
         if (!sessionUser.matchId(id)) {
-            throw new UserSessionException();
+            throw new UserSessionException(ErrorMessage.ILLEGAL_USER);
         }
         return sessionUser;
     }
@@ -52,7 +52,9 @@ public class UserService {
     }
 
     public User findByUserId(String userId) {
-        return this.userRepository.findByUserId(userId).orElseThrow(NotFoundException::new);
+        return this.userRepository.findByUserId(userId).orElseThrow(() ->
+                new EntityNotFoundException(ErrorMessage.USER_NOT_FOUND)
+        );
     }
 
 }

--- a/src/main/resources/static/js/scripts.js
+++ b/src/main/resources/static/js/scripts.js
@@ -47,6 +47,12 @@ function processResponse(errorMessage, url) {
   }
 }
 
+function updateAnswerCount() {
+  let linkDeleteArticle = document.querySelectorAll('a.link-delete-article');
+  let qnaCommentCount = document.querySelector(".qna-comment-count strong");
+  qnaCommentCount.textContent = linkDeleteArticle.length;
+}
+
 function addAnswerEvent() {
   let answerWrite = document.querySelector('form.answer-write button[type=submit]');
   if (answerWrite !== null) {
@@ -66,6 +72,7 @@ function addAnswer(e) {
         document.querySelector('.qna-comment-slipp-articles').insertAdjacentHTML('afterbegin', template);
         document.querySelector('form.answer-write textarea').value = '';
         addDeleteEventToAllAnswer();
+        updateAnswerCount();
       })
 }
 
@@ -86,6 +93,7 @@ function deleteAnswer(e) {
         linkDeleteArticle.forEach(targetQuery => {
           if (targetQuery.href === url) {
             targetQuery.closest('article').remove();
+            updateAnswerCount();
           }
         })
       })

--- a/src/main/resources/static/js/scripts.js
+++ b/src/main/resources/static/js/scripts.js
@@ -1,5 +1,5 @@
 String.prototype.format = function() {
-  var args = arguments;
+  let args = arguments;
   return this.replace(/{(\d+)}/g, function(match, number) {
     return typeof args[number] != 'undefined'
         ? args[number]
@@ -7,3 +7,52 @@ String.prototype.format = function() {
         ;
   });
 };
+
+const redirectUrl = {
+  LOGINPAGE : "http://localhost:8080/user/login"
+}
+
+const errorMessage = {
+  NEEDLOGIN : "로그인이 필요한 서비스입니다."
+}
+
+const request = {
+  post : function post(url, body) {
+    return fetch(url, {
+      method: 'post',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded'
+      },
+      body: body
+    })
+  }
+};
+
+function processResponse(errorMessage, url) {
+  return response => {
+    if (response.status === 200) {
+      return response.json();
+    }
+    alert(errorMessage);
+    window.location.href = url;
+  }
+}
+
+function addAnswer(e) {
+  e.preventDefault();
+  let url = document.querySelector('form.answer-write').action;
+  let body = 'contents=' + document.querySelector('form.answer-write textarea').value;
+  request.post(url, body)
+      .then(processResponse(errorMessage.NEEDLOGIN, redirectUrl.LOGINPAGE))
+      .then(answer => {
+        let answerTemplate = document.querySelector('#answerTemplate').innerHTML;
+        let template = answerTemplate.format(answer.writer.userId, answer.date, answer.contents);
+        document.querySelector('.qna-comment-slipp-articles').insertAdjacentHTML('beforebegin', template);
+        document.querySelector('form.answer-write textarea').value = '';
+      })
+}
+
+let answerWrite = document.querySelector('form.answer-write button[type=submit]');
+if (answerWrite !== null) {
+  answerWrite.addEventListener('click', e => addAnswer(e));
+}

--- a/src/main/resources/static/js/scripts.js
+++ b/src/main/resources/static/js/scripts.js
@@ -68,7 +68,7 @@ function addAnswer(e) {
       .then(processResponse(errorMessage.NEEDLOGIN, redirectUrl.LOGINPAGE))
       .then(answer => {
         let answerTemplate = document.querySelector('#answerTemplate').innerHTML;
-        let template = answerTemplate.format(answer.writer.userId, answer.date, answer.contents, answer.id);
+        let template = answerTemplate.format(answer.writer.userId, answer.modifiedDate, answer.contents, answer.id);
         document.querySelector('.qna-comment-slipp-articles').insertAdjacentHTML('afterbegin', template);
         document.querySelector('form.answer-write textarea').value = '';
         addDeleteEventToAllAnswer();

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -18,7 +18,7 @@
                                 </strong>
                                 <div class="auth-info">
                                     <i class="icon-add-comment"></i>
-                                    <span class="time">{{date}}</span>
+                                    <span class="time">{{modifiedDate}}</span>
                                     <a href="/user/{{writer.userId}}/profile" class="author">{{writer.userId}}</a>
                                 </div>
                                 <div class="reply" title="댓글">

--- a/src/main/resources/templates/qna/show.html
+++ b/src/main/resources/templates/qna/show.html
@@ -73,10 +73,7 @@
                                             <a class="link-modify-article" href="/answer/{{id}}">수정</a>
                                         </li>
                                         <li>
-                                            <form class="delete-answer-form" action="/answer/{{id}}" method="POST">
-                                                <input type="hidden" name="_method" value="DELETE">
-                                                <button type="submit" class="delete-answer-button">삭제</button>
-                                            </form>
+                                            <a class="link-delete-article" href="/api/answer/{{id}}">삭제</a>
                                         </li>
                                     </ul>
                                 </div>
@@ -116,13 +113,10 @@
         <div class="article-util">
             <ul class="article-util-list">
                 <li>
-                    <a class="link-modify-article" href="/api/qna/updateAnswer/{3}">수정</a>
+                    <a class="link-modify-article" href="/answer/{3}">수정</a>
                 </li>
                 <li>
-                    <form class="delete-answer-form" action="/api/questions/{3}/answers/{4}" method="POST">
-                        <input type="hidden" name="_method" value="DELETE">
-                        <button type="submit" class="delete-answer-button">삭제</button>
-                    </form>
+                    <a class="link-delete-article" href="/api/answer/{3}">삭제</a>
                 </li>
             </ul>
         </div>

--- a/src/main/resources/templates/qna/show.html
+++ b/src/main/resources/templates/qna/show.html
@@ -4,100 +4,131 @@
     {{> partial/header}}
 </head>
 <body>
-    {{> partial/navigation}}
-    <div class="container" id="main">
-        <div class="col-md-12 col-sm-12 col-lg-12">
-            <div class="panel panel-default">
-                {{#question}}
-                <header class="qna-header">
-                    <h2 class="qna-title">{{title}}</h2>
-                </header>
-                <div class="content-main">
-                    <article class="article">
-                        <div class="article-header">
-                            <div class="article-header-thumb">
-                                <img src="https://graph.facebook.com/v2.3/100000059371774/picture" class="article-author-thumb" alt="">
-                            </div>
-                            <div class="article-header-text">
-                                <a href="/user/{{writer.userId}}/profile" class="article-author-name">{{writer.userId}}</a>
-                                <a href="/questions/413" class="article-header-time" title="퍼머링크">
-                                    {{date}}
-                                    <i class="icon-link"></i>
-                                </a>
-                            </div>
+{{> partial/navigation}}
+<div class="container" id="main">
+    <div class="col-md-12 col-sm-12 col-lg-12">
+        <div class="panel panel-default">
+            {{#question}}
+            <header class="qna-header">
+                <h2 class="qna-title">{{title}}</h2>
+            </header>
+            <div class="content-main">
+                <article class="article">
+                    <div class="article-header">
+                        <div class="article-header-thumb">
+                            <img src="https://graph.facebook.com/v2.3/100000059371774/picture" class="article-author-thumb" alt="">
                         </div>
-                        <div class="article-doc">
-                            {{contents}}
-                        </div>
-                        <div class="article-util">
-                            <ul class="article-util-list">
-                                <li>
-                                    <a class="link-modify-article" href="/question/{{id}}/form">수정</a>
-                                </li>
-                                <li>
-                                    <form class="form-delete" method="POST" action="/question/{{id}}">
-                                        <input type="hidden" name="_method" value="DELETE">
-                                        <button class="link-delete-article" type="submit">삭제</button>
-                                    </form>
-                                </li>
-                                <li>
-                                    <a class="link-modify-article" href="/">목록</a>
-                                </li>
-                            </ul>
-                        </div>
-                    </article>
-
-                    <div class="qna-comment">
-                        <div class="qna-comment-slipp">
-                            <p class="qna-comment-count"><strong>{{answers.length}}</strong>개의 의견</p>
-                            <div class="qna-comment-slipp-articles">
-                                {{#answers}}
-                                <article class="article" id="answer-1405">
-                                    <div class="article-header">
-                                        <div class="article-header-thumb">
-                                            <img src="https://graph.facebook.com/v2.3/1324855987/picture" class="article-author-thumb" alt="">
-                                        </div>
-                                        <div class="article-header-text">
-                                            <a href="/user/{{writer.userId}}/profile" class="article-author-name">{{writer.userId}}</a>
-                                            <a href="#answer-1434" class="article-header-time" title="퍼머링크">
-                                                {{date}}
-                                            </a>
-                                        </div>
-                                    </div>
-                                    <div class="article-doc comment-doc">
-                                        <p>{{contents}}</p>
-                                    </div>
-                                    <div class="article-util">
-                                        <ul class="article-util-list">
-                                            <li>
-                                                <a class="link-modify-article" href="/answer/{{id}}">수정</a>
-                                            </li>
-                                            <li>
-                                                <form class="delete-answer-form" action="/answer/{{id}}" method="POST">
-                                                    <input type="hidden" name="_method" value="DELETE">
-                                                    <button type="submit" class="delete-answer-button">삭제</button>
-                                                </form>
-                                            </li>
-                                        </ul>
-                                    </div>
-                                </article>
-                                {{/answers}}
-                                <form class="submit-write" name="answer" method="post" action="/answer/{{id}}">
-                                    <div class="form-group" style="padding:14px;">
-                                        <textarea class="form-control" placeholder="Update your status" name="contents"></textarea>
-                                    </div>
-                                    <button class="btn btn-success pull-right" type="submit">답변하기</button>
-                                    <div class="clearfix" />
-                                </form>
-                            </div>
+                        <div class="article-header-text">
+                            <a href="/user/{{writer.userId}}/profile" class="article-author-name">{{writer.userId}}</a>
+                            <a href="/questions/413" class="article-header-time" title="퍼머링크">
+                                {{date}}
+                                <i class="icon-link"></i>
+                            </a>
                         </div>
                     </div>
+                    <div class="article-doc">
+                        {{contents}}
+                    </div>
+                    <div class="article-util">
+                        <ul class="article-util-list">
+                            <li>
+                                <a class="link-modify-article" href="/question/{{id}}/form">수정</a>
+                            </li>
+                            <li>
+                                <form class="form-delete" method="POST" action="/question/{{id}}">
+                                    <input type="hidden" name="_method" value="DELETE">
+                                    <button class="link-delete-article" type="submit">삭제</button>
+                                </form>
+                            </li>
+                            <li>
+                                <a class="link-modify-article" href="/">목록</a>
+                            </li>
+                        </ul>
+                    </div>
+                </article>
 
+                <div class="qna-comment">
+                    <div class="qna-comment-slipp">
+                        <p class="qna-comment-count"><strong>{{answers.length}}</strong>개의 의견</p>
+                        <div class="qna-comment-slipp-articles">
+                            {{#answers}}
+                            <article class="article" id="answer-1405">
+                                <div class="article-header">
+                                    <div class="article-header-thumb">
+                                        <img src="https://graph.facebook.com/v2.3/1324855987/picture" class="article-author-thumb" alt="">
+                                    </div>
+                                    <div class="article-header-text">
+                                        <a href="/user/{{writer.userId}}/profile" class="article-author-name">{{writer.userId}}</a>
+                                        <a href="#answer-1434" class="article-header-time" title="퍼머링크">
+                                            {{date}}
+                                        </a>
+                                    </div>
+                                </div>
+                                <div class="article-doc comment-doc">
+                                    <p>{{contents}}</p>
+                                </div>
+                                <div class="article-util">
+                                    <ul class="article-util-list">
+                                        <li>
+                                            <a class="link-modify-article" href="/answer/{{id}}">수정</a>
+                                        </li>
+                                        <li>
+                                            <form class="delete-answer-form" action="/answer/{{id}}" method="POST">
+                                                <input type="hidden" name="_method" value="DELETE">
+                                                <button type="submit" class="delete-answer-button">삭제</button>
+                                            </form>
+                                        </li>
+                                    </ul>
+                                </div>
+                            </article>
+                            {{/answers}}
+                            <form class="answer-write" name="answer" method="post" action="/api/answer/{{id}}">
+                                <div class="form-group" style="padding:14px;">
+                                    <textarea class="form-control" placeholder="Update your status" name="contents"></textarea>
+                                </div>
+                                <button class="btn btn-success pull-right" type="submit">답변하기</button>
+                                <div class="clearfix" />
+                            </form>
+                        </div>
+                    </div>
                 </div>
-                {{/question}}
+
             </div>
+            {{/question}}
         </div>
     </div>
-    {{> partial/script}}
+</div>
+
+<script type="text/template" id="answerTemplate">
+    <article class="article">
+        <div class="article-header">
+            <div class="article-header-thumb">
+                <img src="https://graph.facebook.com/v2.3/1324855987/picture" class="article-author-thumb" alt="">
+            </div>
+            <div class="article-header-text">
+                <a href="#" class="article-author-name">{0}</a>
+                <div class="article-header-time">{1}</div>
+            </div>
+        </div>
+        <div class="article-doc comment-doc">
+            {2}
+        </div>
+        <div class="article-util">
+            <ul class="article-util-list">
+                <li>
+                    <a class="link-modify-article" href="/api/qna/updateAnswer/{3}">수정</a>
+                </li>
+                <li>
+                    <form class="delete-answer-form" action="/api/questions/{3}/answers/{4}" method="POST">
+                        <input type="hidden" name="_method" value="DELETE">
+                        <button type="submit" class="delete-answer-button">삭제</button>
+                    </form>
+                </li>
+            </ul>
+        </div>
+    </article>
+</script>
+
+{{> partial/script}}
 </body>
 </html>

--- a/src/main/resources/templates/qna/show.html
+++ b/src/main/resources/templates/qna/show.html
@@ -21,7 +21,7 @@
                         <div class="article-header-text">
                             <a href="/user/{{writer.userId}}/profile" class="article-author-name">{{writer.userId}}</a>
                             <a href="/questions/413" class="article-header-time" title="퍼머링크">
-                                {{date}}
+                                {{modifiedDate}}
                                 <i class="icon-link"></i>
                             </a>
                         </div>
@@ -60,7 +60,7 @@
                                     <div class="article-header-text">
                                         <a href="/user/{{writer.userId}}/profile" class="article-author-name">{{writer.userId}}</a>
                                         <a href="#answer-1434" class="article-header-time" title="퍼머링크">
-                                            {{date}}
+                                            {{modifiedDate}}
                                         </a>
                                     </div>
                                 </div>


### PR DESCRIPTION
현재 비비와 짝코딩을 진행하고 있습니다. 원래 계획은 비비 과제 먼저 끝내고 제 미션을 진행하려 했습니다. 그런데 생각보다 진행이 빠르지 못해 비비 미션만 진행하는 것도 빠듯할 것 같아 진행하던 제 미션을 마무리 하여 pr을 보냅니다.

미션4에서 이번 미션5로 눈에 띄게 바뀐 것은

1. ErrorException enum을 만들어 에러 메세지를 상수로 관리하도록 했습니다. enum 사용을 결정한 이유는 GlobalExceptionHandler 클래스의 handleUserAccountException 메서드에서 메세지에 따라 보여줄 view를 달리할 필요가 있었습니다. 그리고 다른 에러 메세지들도 enum을 만들었기에 포함시켜 리팩토링 했습니다.

2. 답변 생성, 수정, 삭제에 있어서 자바스크립트를 이용해 변경되는 부분만 로딩이 되도록 진행했습니다. 자바지기 영상에 나와있지 않은 부분도 몇가지 추가를 했습니다. 답변에 대한 권한이 없다면 경고창을 띄우고 로그인 페이지로 이동하도록 구현했으며 ajax를 이용해 답변이 생성될 때 전체 답변 개수를 표시하는 부분도 제대로 변경이 되도록 했습니다.

3. 엔티티의 공통부분인 id, 생성일, 수정일을 AbstractEntity 클래스를 만들어 중복을 제거 했습니다.

4. Swagger 라이브러리를 사용하여 api 문서를 볼 수 있도록 설정 했습니다.

이번 리뷰도 잘 부탁드려요!!
좋은 하루 되세요ㅎㅎ

배포링크 : https://enolj-spring-qna.herokuapp.com